### PR TITLE
Add missing header.

### DIFF
--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -15,6 +15,7 @@
 #include <ui_interface.h>
 
 #include <memory>
+#include <deque>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
This is required for building with GCC 9.2.
There's a missing Deque include in httpserver.cpp.

