### PR TITLE
Propose new decay rate for block rewards

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1224,10 +1224,10 @@ CAmount GetDGBSubsidy(int nHeight, const Consensus::Params& consensusParams) {
 		//decrease reward by 1% every month
 		for(int i = 0; i < weeks; i++)  qSubsidy -= (qSubsidy/100);
 	}
-	else
+	else if(nHeight<12993200)
 	{
 		//hard fork point: 1.43M
-		//subsidy at hard fork: 2157
+		//subsidy at hard fork: 1078.5
 		//monthly decay factor: 98884/100000
 		//last block number: 41668798
 		//expected years after hard fork: 19.1395
@@ -1238,6 +1238,22 @@ CAmount GetDGBSubsidy(int nHeight, const Consensus::Params& consensusParams) {
 		for(int64_t i = 0; i < months; i++)
 		{
 			qSubsidy*=98884;
+			qSubsidy/=100000;
+		}
+	} else {
+		//hard fork point: 12993200
+		//subsidy at hard fork: 513.00043026
+		//monthly decay factor: 98652/100000
+		//last block number: 116731970
+		//expected years after hard fork: 49.343
+
+
+		qSubsidy = 51300043026*COIN/100000000;
+		int64_t blocks = nHeight - 12993200;
+		int64_t months = blocks*15/(3600*24*365/12);
+		for(int64_t i = 0; i < months; i++)
+		{
+			qSubsidy*=98652;
 			qSubsidy/=100000;
 		}
 	}


### PR DESCRIPTION
DigiByte current block rewards end on block 40265288 with 90.29 DGB/block this is a huge drop to 0 and probably way to close to the current date for tx fees to take over.

I propose we change the decay rate of the rewards at block 12993200 from 0.98884 to 0.98652 this will make almost no difference to rewards over the next 5 years but will stretch the rewards phase to block 116731970 with a 0.16 DGB/block reward.

I have written a block reward simulator so you can easily double check my math available at https://github.com/mctrivia/dgb_reward_simulator