### PR TITLE
test: correct blockencodings_tests

### DIFF
--- a/src/test/blockencodings_tests.cpp
+++ b/src/test/blockencodings_tests.cpp
@@ -49,7 +49,7 @@ static CBlock BuildBlockTestCase() {
     bool mutated;
     block.hashMerkleRoot = BlockMerkleRoot(block, &mutated);
     assert(!mutated);
-    while (!CheckProofOfWork(block.GetHash(), block.nBits, Params().GetConsensus())) ++block.nNonce;
+    while (!CheckProofOfWork(block.GetPoWAlgoHash(Params().GetConsensus()), block.nBits, Params().GetConsensus())) ++block.nNonce;
     return block;
 }
 
@@ -297,7 +297,7 @@ BOOST_AUTO_TEST_CASE(EmptyBlockRoundTripTest)
     bool mutated;
     block.hashMerkleRoot = BlockMerkleRoot(block, &mutated);
     assert(!mutated);
-    while (!CheckProofOfWork(block.GetHash(), block.nBits, Params().GetConsensus())) ++block.nNonce;
+    while (!CheckProofOfWork(block.GetPoWAlgoHash(Params().GetConsensus()), block.nBits, Params().GetConsensus())) ++block.nNonce;
 
     // Test simple header round-trip with only coinbase
     {

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -46,6 +46,7 @@
 
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/thread.hpp>
+#include <boost/bind.hpp>
 
 #if defined(NDEBUG)
 # error "DigiByte cannot be compiled without assertions."

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -17,6 +17,7 @@
 #include <atomic>
 #include <future>
 
+#include <boost/bind.hpp>
 #include <boost/signals2/signal.hpp>
 
 struct MainSignalsInstance {


### PR DESCRIPTION
This PR corrects the unit tests for blockencodings_tests.cpp

Running this test as it was previously, resulted in an error message that differed per run (!), indicating a bad memory access. Once the hashing function was correctly set; this no longer occurred.

This test can be launched by running (from src/test):
```
./test_digibyte --run_test=blockencodings_tests
```