### PR TITLE
test: correct key_io_tests

### DIFF
--- a/src/test/data/key_io_invalid.json
+++ b/src/test/data/key_io_invalid.json
@@ -6,177 +6,147 @@
         "x"
     ],
     [
-        "37qgekLpCCHrQuSjvX3fs496FWTGsHFHizjJAs6NPcR47aefnnCWECAhHV6E3g4YN7u7Yuwod5Y"
+        "Z2bQQMPG4ipph1htYtjVydXjQcrSQiW3FV"
     ],
     [
-        "dzb7VV1Ui55BARxv7ATxAtCUeJsANKovDGWFVgpTbhq9gvPqP3yv"
+        "s43j3NtP4rQhqjs7bjE1B3rHnyHw4SkXnzfhzJJR7twPKscMUvt6QiPxM13ibjysJ5BoMbs9LrE"
     ],
     [
-        "MuNu7ZAEDFiHthiunm7dPjwKqrVNCM3mAz6rP9zFveQu14YA8CxExSJTHcVP9DErn6u84E6Ej7S"
+        "2Kijg2M2athYxg4a8BCK4xZN3ftA9hzTvnG"
     ],
     [
-        "rPpQpYknyNQ5AEHuY6H8ijJJrYc2nDKKk9jjmKEXsWzyAQcFGpDLU2Zvsmoi8JLR7hAwoy3RQWf"
+        "ntkBEhaHa71WyWbuoaWqGD1duP8LURZPKfDjLTJ2dqQAR1CyHPZizzXz2UkPbeMCTUxeYZBqWUH"
     ],
     [
-        "4Uc3FmN6NQ6zLBK5QQBXRBUREaaHwCZYsGCueHauuDmJpZKn6jkEskMB2Zi2CNgtb5r6epWEFfUJq"
+        "3h9ZvjWYBzLzSKEZPp2YwaM57JKkNVCHDvja5zzrP9sRE21ac5P"
     ],
     [
-        "7aQgR5DFQ25vyXmqZAWmnVCjL3PkBcdVkBUpjrjMTcghHx3E8wb"
+        "tc1qc2u34lv5j5mrfw2zuua8jnh4kqueeyfvatzu7h"
     ],
     [
-        "17QpPprjeg69fW1DV8DcYYCKvWjYhXvWkov6MJ1iTTvMFj6weAqW7wybZeH57WTNxXVCRH4veVs"
+        "dgbt13utfhgatr22fcgzy2m6fvaukcjn05xw97cea9emv7tkvdpvmavwnqdzvy9l"
     ],
     [
-        "KxuACDviz8Xvpn1xAh9MfopySZNuyajYMZWz16Dv2mHHryznWUp3"
+        "dgbrt1rx52vny8u"
     ],
     [
-        "7nK3GSmqdXJQtdohvGfJ7KsSmn3TmGqExug49583bDAL91pVSGq5xS9SHoAYL3Wv3ijKTit65th"
+        "DGB109JEQTRMGG3JCXL6A30657K8NQLNTTF2FAZ8WHTM80RZWS3QZF5WFVHY9KRM2JD89PSLHQQCQ"
     ],
     [
-        "cTivdBmq7bay3RFGEBBuNfMh2P1pDCgRYN2Wbxmgwr4ki3jNUL2va"
+        "dgbt1dyelee"
     ],
     [
-        "gjMV4vjNjyMrna4fsAr8bWxAbwtmMUBXJS3zL4NJt5qjozpbQLmAfK1uA3CquSqsZQMpoD1g2nk"
+        "dgbrt1qkcmpf"
     ],
     [
-        "emXm1naBMoVzPjbk7xpeTVMFy4oDEe25UmoyGgKEB1gGWsK8kRGs"
+        "dgb1qmnk6nq5339m7kqegywqjc788guq8nxqwm"
     ],
     [
-        "7VThQnNRj1o3Zyvc7XHPRrjDf8j2oivPTeDXnRPYWeYGE4pXeRJDZgf28ppti5hsHWXS2GSobdqyo"
+        "dgbt1qpvax6t5suk4spcyxh9m4297cg47hh0pqzhfmuw9lzt3azlx46h0q944kkf"
     ],
     [
-        "1G9u6oCVCPh2o8m3t55ACiYvG1y5BHewUkDSdiQarDcYXXhFHYdzMdYfUAhfxn5vNZBwpgUNpso"
+        "dgbrt1q6zs3z0zscfyqtZNXUrrxt5n5p257nnaxnt8xr7"
     ],
     [
-        "31QQ7ZMLkScDiB4VyZjuptr7AEc9j1SjstF7pRoLhHTGkW4Q2y9XELobQmhhWxeRvqcukGd1XCq"
+        "2FNrbmXrP6295pskg5Zp2vuL3dESEi4vPL6Y3xeSuPVhYuy7mGKCK6pLrw6T818xYqS4QUkZ4rv6"
     ],
     [
-        "DHqKSnpxa8ZdQyH8keAhvLTrfkyBMQxqngcQA5N8LQ9KVt25kmGN"
+        "s5fbqL3aWGNMEgsXLfxgitPnhBhiLmDPDxefZFwDgT7vsYqfnNi7Jk5fe2gT6JqkJQmYhvaxCaq"
     ],
     [
-        "2LUHcJPbwLCy9GLH1qXmfmAwvadWw4bp4PCpDfduLqV17s6iDcy1imUwhQJhAoNoN1XNmweiJP4i"
+        "JodnNy72GH7VfMesJWUoSWPkP4p1r4Uke1qq7svDTJPYchVLoero"
     ],
     [
-        "7USRzBXAnmck8fX9HmW7RAb4qt92VFX6soCnts9s74wxm4gguVhtG5of8fZGbNPJA83irHVY6bCos"
+        "tc1qrrssdgr9knj6y0hswcwj84srel4h37xcw06agg"
     ],
     [
-        "1DGezo7BfVebZxAbNT3XGujdeHyNNBF3vnficYoTSp4PfK2QaML9bHzAMxke3wdKdHYWmsMTJVu"
+        "dgbt1dyelee"
     ],
     [
-        "2D12DqDZKwCxxkzs1ZATJWvgJGhQ4cFi3WrizQ5zLAyhN5HxuAJ1yMYaJp8GuYsTLLxTAz6otCfb"
+        "dgbrt1r8c5065aa"
     ],
     [
-        "8AFJzuTujXjw1Z6M3fWhQ1ujDW7zsV4ePeVjVo7D1egERqSW9nZ"
+        "dgb10trdcpd20jfsftmt4llymgfyhhwz6ewpqnnywvasrywxnykc8efqx7dvj3wggrvqzry78m34w"
     ],
     [
-        "163Q17qLbTCue8YY3AvjpUhotuaodLm2uqMhpYirsKjVqnxJRWTEoywMVY3NbBAHuhAJ2cF9GAZ"
+        "dgbt1qsamc3psvgwe8kxu520a9w56pgyspswgn"
     ],
     [
-        "2MnmgiRH4eGLyLc9eAqStzk7dFgBjFtUCtu"
+        "DGBRT1QHUHNZPA3GSVR57E9SJKVQ60NTS9QARLMZVPLUQMYN35SPHH9VZP3VT6HUW"
     ],
     [
-        "461QQ2sYWxU7H2PV4oBwJGNch8XVTYYbZxU"
+        "dgb1qpvthsxfw3cmr70v6vz0xnkllcyqk3zrsn"
     ],
     [
-        "2UCtv53VttmQYkVU4VMtXB31REvQg4ABzs41AEKZ8UcB7DAfVzdkV9JDErwGwyj5AUHLkmgZeobs"
+        "dgbt1q74dl8zr0uk6pe7zq03aqzk47jthdsv65chfcrlvu5jl65ux5upjqw43arr"
     ],
     [
-        "cSNjAsnhgtiFMi6MtfvgscMB2Cbhn2v1FUYfviJ1CdjfidvmeW6mn"
+        "dgbrt1qm3wc8lztwt5852ktu5nkyYS7803jknmge5f462"
     ],
     [
-        "gmsow2Y6EWAFDFE1CE4Hd3Tpu2BvfmBfG1SXsuRARbnt1WjkZnFh1qGTiptWWbjsq2Q6qvpgJVj"
+        "BvkL9ZqkAaq1qYMYGppe3srsH33fqmUDhccNtfVe56UGyBA8LT2TWdvChM8oX2BVqjTrJheytL5"
     ],
     [
-        "nksUKSkzS76v8EsSgozXGMoQFiCoCHzCVajFKAXqzK5on9ZJYVHMD5CKwgmX3S3c7M1U3xabUny"
+        "2d2dWvTSqAikiS1j7Nsd3mhQs1Pyj1VwK9s"
     ],
     [
-        "L3favK1UzFGgdzYBF2oBT5tbayCo4vtVBLJhg2iYuMeePxWG8SQc"
+        "npKHxjNZPjNkWjSedQE1DQsgWMBZPbsiRH9oggY21dPHD4YUKPbosX6Dq13FjcEv7GEeo5HkX9d"
     ],
     [
-        "7VxLxGGtYT6N99GdEfi6xz56xdQ8nP2dG1CavuXx7Rf2PrvNMTBNevjkfgs9JmkcGm6EXpj8ipyPZ"
+        "ei5kPaqYLuZHN9A5w1ar5CK1wkRc5rwzwkYWPZMRFW4rNa9fRdRD"
     ],
     [
-        "2mbZwFXF6cxShaCo2czTRB62WTx9LxhTtpP"
+        "2673RQdBFf63fKr95ZXMJ2pQ28KYRw4WcUaeb8iaL6nhBpx3AVH"
     ],
     [
-        "dB7cwYdcPSgiyAwKWL3JwCVwSk6epU2txw"
+        "tc19jm4rn"
     ],
     [
-        "HPhFUhUAh8ZQQisH8QQWafAxtQYju3SFTX"
+        "dgbt133wls293etvvkacktcymqmflkgrlhn0zef9rec4mj7v0el90sp03sc9g7mk"
     ],
     [
-        "4ctAH6AkHzq5ioiM1m9T3E2hiYEev5mTsB"
+        "dgbrt1rey786e5l"
     ],
     [
-        "Hn1uFi4dNexWrqARpjMqgT6cX1UsNPuV3cHdGg9ExyXw8HTKadbktRDtdeVmY3M1BxJStiL4vjJ"
+        "dgb10ygmkxdzluzt2fphn7w9qxyuwpl0h3058mya7uqrwqht6zhvfmtsg9menyae50n3dxumdr9fz"
     ],
     [
-        "Sq3fDbvutABmnAHHExJDgPLQn44KnNC7UsXuT7KZecpaYDMU9Txs"
+        "dgbt1q79z22zraevtdqjp045yejfz39qs808sn"
     ],
     [
-        "6TqWyrqdgUEYDQU1aChMuFMMEimHX44qHFzCUgGfqxGgZNMUVWJ"
+        "dgbrt1qvenquc3klaytctc76veszpc09pkq7xk264rdgkr4hde0gv5lhwj3a3mst5"
     ],
     [
-        "giqJo7oWqFxNKWyrgcBxAVHXnjJ1t6cGoEffce5Y1y7u649Noj5wJ4mmiUAKEVVrYAGg2KPB3Y4"
+        "dgb1ql6eyq7up9xy77xfrwd4a5ulxvgquu7l67"
     ],
     [
-        "cNzHY5e8vcmM3QVJUcjCyiKMYfeYvyueq5qCMV3kqcySoLyGLYUK"
+        "dgbt1qjfqzapd7se5yq898qsapuf4rplukv6n9l7p4w92l8tt6qfdzkxzqxa2ajf"
     ],
     [
-        "37uTe568EYc9WLoHEd9jXEvUiWbq5LFLscNyqvAzLU5vBArUJA6eydkLmnMwJDjkL5kXc2VK7ig"
+        "dgbrt1qKCMPf"
     ],
     [
-        "EsYbG4tWWWY45G31nox838qNdzksbPySWc"
+        "2QNAtoEpVQgh6kwpzChfGRsdcWLph7CLgZE"
     ],
     [
-        "nbuzhfwMoNzA3PaFnyLcRxE9bTJPDkjZ6Rf6Y6o2ckXZfzZzXBT"
+        "spmoYWHEr3SbjqF7D5utUuKT2qYMkRTWPF6"
     ],
     [
-        "cQN9PoxZeCWK1x56xnz6QYAsvR11XAce3Ehp3gMUdfSQ53Y2mPzx"
+        "yeJdtpUxd2XAMTJtKDscFBpYRqgWspCc3u"
     ],
     [
-        "1Gm3N3rkef6iMbx4voBzaxtXcmmiMTqZPhcuAepRzYUJQW4qRpEnHvMojzof42hjFRf8PE2jPde"
+        "mzg2FztHLnAnZmcwYFKJn6XuCFkHB3EzWWucPmbCwbdSuXe9sDBY7QkFwPvgCFeocjvbqrajuGz"
     ],
     [
-        "2TAq2tuN6x6m233bpT7yqdYQPELdTDJn1eU"
+        "5Hyb47fZ1tQupmumQRgjG9k5zthDfTGToTCpU6A8yUD7HJPDicv"
     ],
     [
-        "ntEtnnGhqPii4joABvBtSEJG6BxjT2tUZqE8PcVYgk3RHpgxgHDCQxNbLJf7ardf1dDk2oCQ7Cf"
+        "4V5gPR85KA6Fp8Qp7goer1y8jyxKJiDiMHqgZVgDD2Bh4qcTDF9R4U4h18xfgH4238KkSFhE9uNeU"
     ],
     [
-        "Ky1YjoZNgQ196HJV3HpdkecfhRBmRZdMJk89Hi5KGfpfPwS2bUbfd"
+        "tc1qjjryhad30rucfqr4s3f9463d785ylrg6kh4aeg"
     ],
     [
-        "2A1q1YsMZowabbvta7kTy2Fd6qN4r5ZCeG3qLpvZBMzCixMUdkN2Y4dHB1wPsZAeVXUGD83MfRED"
-    ],
-    [
-        "tc1qw508d6qejxtdg4y5r3zarvary0c5xw7kg3g4ty"
-    ],
-    [
-        "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t5"
-    ],
-    [
-        "BC13W508D6QEJXTDG4Y5R3ZARVARY0C5XW7KN40WF2"
-    ],
-    [
-        "bc1rw5uspcuh"
-    ],
-    [
-        "bc10w508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7kw5rljs90"
-    ],
-    [
-        "BC1QR508D6QEJXTDG4Y5R3ZARVARYV98GJ9P"
-    ],
-    [
-        "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sL5k7"
-    ],
-    [
-        "bc1zw508d6qejxtdg4y5r3zarvaryvqyzf3du"
-    ],
-    [
-        "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3pjxtptv"
-    ],
-    [
-        "bc1gmk9yu"
+        "dgbt13nu8tnp9k95q3s2sd0dxf2hxjdqvs69e0z05tpg6rhv0nmhggtuxq6ljjhf"
     ]
 ]

--- a/src/test/data/key_io_valid.json
+++ b/src/test/data/key_io_valid.json
@@ -1,533 +1,434 @@
 [
     [
-        "1AGNa15ZQXAZUgFiqJ2i7Z2DPU2J6hW62i",
-        "76a91465a16059864a2fdbc7c99a4723a8395bc6f188eb88ac",
+        "D9RHWmrnxFR7xpmxunXRNvTNbq1MB7N6Da",
+        "76a9142ef051cac2e6f13bdb689a2805ddcbd69634dd2388ac",
         {
-            "isPrivkey": false,
-            "chain": "main"
-        }
-    ],
-    [
-        "3CMNFxN1oHBc4R1EpboAL5yzHGgE611Xou",
-        "a91474f209f6ea907e2ea48f74fae05782ae8a66525787",
-        {
-            "isPrivkey": false,
-            "chain": "main"
-        }
-    ],
-    [
-        "mo9ncXisMeAoXwqcV5EWuyncbmCcQN4rVs",
-        "76a91453c0307d6851aa0ce7825ba883c6bd9ad242b48688ac",
-        {
-            "isPrivkey": false,
-            "chain": "test"
-        }
-    ],
-    [
-        "mo9ncXisMeAoXwqcV5EWuyncbmCcQN4rVs",
-        "76a91453c0307d6851aa0ce7825ba883c6bd9ad242b48688ac",
-        {
-            "isPrivkey": false,
-            "chain": "regtest"
-        }
-    ],
-    [
-        "2N2JD6wb56AfK4tfmM6PwdVmoYk2dCKf4Br",
-        "a9146349a418fc4578d10a372b54b45c280cc8c4382f87",
-        {
-            "isPrivkey": false,
-            "chain": "test"
-        }
-    ],
-    [
-        "5Kd3NBUAdUnhyzenEwVLy9pBKxSwXvE9FMPyR4UKZvpe6E3AgLr",
-        "eddbdc1168f1daeadbd3e44c1e3f8f5a284c2029f78ad26af98583a499de5b19",
-        {
-            "isCompressed": false,
-            "isPrivkey": true,
-            "chain": "main"
-        }
-    ],
-    [
-        "Kz6UJmQACJmLtaQj5A3JAge4kVTNQ8gbvXuwbmCj7bsaabudb3RD",
-        "55c9bccb9ed68446d1b75273bbce89d7fe013a8acd1625514420fb2aca1a21c4",
-        {
-            "isCompressed": true,
-            "isPrivkey": true,
-            "chain": "main"
-        }
-    ],
-    [
-        "9213qJab2HNEpMpYNBa7wHGFKKbkDn24jpANDs2huN3yi4J11ko",
-        "36cb93b9ab1bdabf7fb9f2c04f1b9cc879933530ae7842398eef5a63a56800c2",
-        {
-            "isCompressed": false,
-            "isPrivkey": true,
-            "chain": "test"
-        }
-    ],
-    [
-        "9213qJab2HNEpMpYNBa7wHGFKKbkDn24jpANDs2huN3yi4J11ko",
-        "36cb93b9ab1bdabf7fb9f2c04f1b9cc879933530ae7842398eef5a63a56800c2",
-        {
-            "isCompressed": false,
-            "isPrivkey": true,
-            "chain": "regtest"
-        }
-    ],
-    [
-        "cTpB4YiyKiBcPxnefsDpbnDxFDffjqJob8wGCEDXxgQ7zQoMXJdH",
-        "b9f4892c9e8282028fea1d2667c4dc5213564d41fc5783896a0d843fc15089f3",
-        {
-            "isCompressed": true,
-            "isPrivkey": true,
-            "chain": "test"
-        }
-    ],
-    [
-        "cTpB4YiyKiBcPxnefsDpbnDxFDffjqJob8wGCEDXxgQ7zQoMXJdH",
-        "b9f4892c9e8282028fea1d2667c4dc5213564d41fc5783896a0d843fc15089f3",
-        {
-            "isCompressed": true,
-            "isPrivkey": true,
-            "chain": "regtest"
-        }
-    ],
-    [
-        "1Ax4gZtb7gAit2TivwejZHYtNNLT18PUXJ",
-        "76a9146d23156cbbdcc82a5a47eee4c2c7c583c18b6bf488ac",
-        {
-            "isPrivkey": false,
-            "chain": "main"
-        }
-    ],
-    [
-        "3QjYXhTkvuj8qPaXHTTWb5wjXhdsLAAWVy",
-        "a914fcc5460dd6e2487c7d75b1963625da0e8f4c597587",
-        {
-            "isPrivkey": false,
-            "chain": "main"
-        }
-    ],
-    [
-        "n3ZddxzLvAY9o7184TB4c6FJasAybsw4HZ",
-        "76a914f1d470f9b02370fdec2e6b708b08ac431bf7a5f788ac",
-        {
-            "isPrivkey": false,
-            "chain": "test"
-        }
-    ],
-    [
-        "2NBFNJTktNa7GZusGbDbGKRZTxdK9VVez3n",
-        "a914c579342c2c4c9220205e2cdc285617040c924a0a87",
-        {
-            "isPrivkey": false,
-            "chain": "test"
-        }
-    ],
-    [
-        "5K494XZwps2bGyeL71pWid4noiSNA2cfCibrvRWqcHSptoFn7rc",
-        "a326b95ebae30164217d7a7f57d72ab2b54e3be64928a19da0210b9568d4015e",
-        {
-            "isCompressed": false,
-            "isPrivkey": true,
-            "chain": "main"
-        }
-    ],
-    [
-        "L1RrrnXkcKut5DEMwtDthjwRcTTwED36thyL1DebVrKuwvohjMNi",
-        "7d998b45c219a1e38e99e7cbd312ef67f77a455a9b50c730c27f02c6f730dfb4",
-        {
-            "isCompressed": true,
-            "isPrivkey": true,
-            "chain": "main"
-        }
-    ],
-    [
-        "93DVKyFYwSN6wEo3E2fCrFPUp17FtrtNi2Lf7n4G3garFb16CRj",
-        "d6bca256b5abc5602ec2e1c121a08b0da2556587430bcf7e1898af2224885203",
-        {
-            "isCompressed": false,
-            "isPrivkey": true,
-            "chain": "test"
-        }
-    ],
-    [
-        "cTDVKtMGVYWTHCb1AFjmVbEbWjvKpKqKgMaR3QJxToMSQAhmCeTN",
-        "a81ca4e8f90181ec4b61b6a7eb998af17b2cb04de8a03b504b9e34c4c61db7d9",
-        {
-            "isCompressed": true,
-            "isPrivkey": true,
-            "chain": "test"
-        }
-    ],
-    [
-        "1C5bSj1iEGUgSTbziymG7Cn18ENQuT36vv",
-        "76a9147987ccaa53d02c8873487ef919677cd3db7a691288ac",
-        {
-            "isPrivkey": false,
-            "chain": "main"
-        }
-    ],
-    [
-        "3AnNxabYGoTxYiTEZwFEnerUoeFXK2Zoks",
-        "a91463bcc565f9e68ee0189dd5cc67f1b0e5f02f45cb87",
-        {
-            "isPrivkey": false,
-            "chain": "main"
-        }
-    ],
-    [
-        "n3LnJXCqbPjghuVs8ph9CYsAe4Sh4j97wk",
-        "76a914ef66444b5b17f14e8fae6e7e19b045a78c54fd7988ac",
-        {
-            "isPrivkey": false,
-            "chain": "test"
-        }
-    ],
-    [
-        "2NB72XtkjpnATMggui83aEtPawyyKvnbX2o",
-        "a914c3e55fceceaa4391ed2a9677f4a4d34eacd021a087",
-        {
-            "isPrivkey": false,
-            "chain": "test"
-        }
-    ],
-    [
-        "5KaBW9vNtWNhc3ZEDyNCiXLPdVPHCikRxSBWwV9NrpLLa4LsXi9",
-        "e75d936d56377f432f404aabb406601f892fd49da90eb6ac558a733c93b47252",
-        {
-            "isCompressed": false,
-            "isPrivkey": true,
-            "chain": "main"
-        }
-    ],
-    [
-        "L1axzbSyynNYA8mCAhzxkipKkfHtAXYF4YQnhSKcLV8YXA874fgT",
-        "8248bd0375f2f75d7e274ae544fb920f51784480866b102384190b1addfbaa5c",
-        {
-            "isCompressed": true,
-            "isPrivkey": true,
-            "chain": "main"
-        }
-    ],
-    [
-        "927CnUkUbasYtDwYwVn2j8GdTuACNnKkjZ1rpZd2yBB1CLcnXpo",
-        "44c4f6a096eac5238291a94cc24c01e3b19b8d8cef72874a079e00a242237a52",
-        {
-            "isCompressed": false,
-            "isPrivkey": true,
-            "chain": "test"
-        }
-    ],
-    [
-        "cUcfCMRjiQf85YMzzQEk9d1s5A4K7xL5SmBCLrezqXFuTVefyhY7",
-        "d1de707020a9059d6d3abaf85e17967c6555151143db13dbb06db78df0f15c69",
-        {
-            "isCompressed": true,
-            "isPrivkey": true,
-            "chain": "test"
-        }
-    ],
-    [
-        "1Gqk4Tv79P91Cc1STQtU3s1W6277M2CVWu",
-        "76a914adc1cc2081a27206fae25792f28bbc55b831549d88ac",
-        {
-            "isPrivkey": false,
-            "chain": "main"
-        }
-    ],
-    [
-        "33vt8ViH5jsr115AGkW6cEmEz9MpvJSwDk",
-        "a914188f91a931947eddd7432d6e614387e32b24470987",
-        {
-            "isPrivkey": false,
-            "chain": "main"
-        }
-    ],
-    [
-        "mhaMcBxNh5cqXm4aTQ6EcVbKtfL6LGyK2H",
-        "76a9141694f5bc1a7295b600f40018a618a6ea48eeb49888ac",
-        {
-            "isPrivkey": false,
-            "chain": "test"
-        }
-    ],
-    [
-        "2MxgPqX1iThW3oZVk9KoFcE5M4JpiETssVN",
-        "a9143b9b3fd7a50d4f08d1a5b0f62f644fa7115ae2f387",
-        {
-            "isPrivkey": false,
-            "chain": "test"
-        }
-    ],
-    [
-        "5HtH6GdcwCJA4ggWEL1B3jzBBUB8HPiBi9SBc5h9i4Wk4PSeApR",
-        "091035445ef105fa1bb125eccfb1882f3fe69592265956ade751fd095033d8d0",
-        {
-            "isCompressed": false,
-            "isPrivkey": true,
-            "chain": "main"
-        }
-    ],
-    [
-        "L2xSYmMeVo3Zek3ZTsv9xUrXVAmrWxJ8Ua4cw8pkfbQhcEFhkXT8",
-        "ab2b4bcdfc91d34dee0ae2a8c6b6668dadaeb3a88b9859743156f462325187af",
-        {
-            "isCompressed": true,
-            "isPrivkey": true,
-            "chain": "main"
-        }
-    ],
-    [
-        "92xFEve1Z9N8Z641KQQS7ByCSb8kGjsDzw6fAmjHN1LZGKQXyMq",
-        "b4204389cef18bbe2b353623cbf93e8678fbc92a475b664ae98ed594e6cf0856",
-        {
-            "isCompressed": false,
-            "isPrivkey": true,
-            "chain": "test"
-        }
-    ],
-    [
-        "92xFEve1Z9N8Z641KQQS7ByCSb8kGjsDzw6fAmjHN1LZGKQXyMq",
-        "b4204389cef18bbe2b353623cbf93e8678fbc92a475b664ae98ed594e6cf0856",
-        {
-            "isCompressed": false,
-            "isPrivkey": true,
-            "chain": "regtest"
-        }
-    ],
-    [
-        "cVM65tdYu1YK37tNoAyGoJTR13VBYFva1vg9FLuPAsJijGvG6NEA",
-        "e7b230133f1b5489843260236b06edca25f66adb1be455fbd38d4010d48faeef",
-        {
-            "isCompressed": true,
-            "isPrivkey": true,
-            "chain": "test"
-        }
-    ],
-    [
-        "1JwMWBVLtiqtscbaRHai4pqHokhFCbtoB4",
-        "76a914c4c1b72491ede1eedaca00618407ee0b772cad0d88ac",
-        {
-            "isPrivkey": false,
-            "chain": "main"
-        }
-    ],
-    [
-        "3QCzvfL4ZRvmJFiWWBVwxfdaNBT8EtxB5y",
-        "a914f6fe69bcb548a829cce4c57bf6fff8af3a5981f987",
-        {
-            "isPrivkey": false,
-            "chain": "main"
-        }
-    ],
-    [
-        "mizXiucXRCsEriQCHUkCqef9ph9qtPbZZ6",
-        "76a914261f83568a098a8638844bd7aeca039d5f2352c088ac",
-        {
-            "isPrivkey": false,
-            "chain": "test"
-        }
-    ],
-    [
-        "2NEWDzHWwY5ZZp8CQWbB7ouNMLqCia6YRda",
-        "a914e930e1834a4d234702773951d627cce82fbb5d2e87",
-        {
-            "isPrivkey": false,
-            "chain": "test"
-        }
-    ],
-    [
-        "5KQmDryMNDcisTzRp3zEq9e4awRmJrEVU1j5vFRTKpRNYPqYrMg",
-        "d1fab7ab7385ad26872237f1eb9789aa25cc986bacc695e07ac571d6cdac8bc0",
-        {
-            "isCompressed": false,
-            "isPrivkey": true,
-            "chain": "main"
-        }
-    ],
-    [
-        "L39Fy7AC2Hhj95gh3Yb2AU5YHh1mQSAHgpNixvm27poizcJyLtUi",
-        "b0bbede33ef254e8376aceb1510253fc3550efd0fcf84dcd0c9998b288f166b3",
-        {
-            "isCompressed": true,
-            "isPrivkey": true,
-            "chain": "main"
-        }
-    ],
-    [
-        "91cTVUcgydqyZLgaANpf1fvL55FH53QMm4BsnCADVNYuWuqdVys",
-        "037f4192c630f399d9271e26c575269b1d15be553ea1a7217f0cb8513cef41cb",
-        {
-            "isCompressed": false,
-            "isPrivkey": true,
-            "chain": "test"
-        }
-    ],
-    [
-        "cQspfSzsgLeiJGB2u8vrAiWpCU4MxUT6JseWo2SjXy4Qbzn2fwDw",
-        "6251e205e8ad508bab5596bee086ef16cd4b239e0cc0c5d7c4e6035441e7d5de",
-        {
-            "isCompressed": true,
-            "isPrivkey": true,
-            "chain": "test"
-        }
-    ],
-    [
-        "19dcawoKcZdQz365WpXWMhX6QCUpR9SY4r",
-        "76a9145eadaf9bb7121f0f192561a5a62f5e5f5421029288ac",
-        {
-            "isPrivkey": false,
-            "chain": "main"
-        }
-    ],
-    [
-        "37Sp6Rv3y4kVd1nQ1JV5pfqXccHNyZm1x3",
-        "a9143f210e7277c899c3a155cc1c90f4106cbddeec6e87",
-        {
-            "isPrivkey": false,
-            "chain": "main"
-        }
-    ],
-    [
-        "myoqcgYiehufrsnnkqdqbp69dddVDMopJu",
-        "76a914c8a3c2a09a298592c3e180f02487cd91ba3400b588ac",
-        {
-            "isPrivkey": false,
-            "chain": "test"
-        }
-    ],
-    [
-        "2N7FuwuUuoTBrDFdrAZ9KxBmtqMLxce9i1C",
-        "a91499b31df7c9068d1481b596578ddbb4d3bd90baeb87",
-        {
-            "isPrivkey": false,
-            "chain": "test"
-        }
-    ],
-    [
-        "5KL6zEaMtPRXZKo1bbMq7JDjjo1bJuQcsgL33je3oY8uSJCR5b4",
-        "c7666842503db6dc6ea061f092cfb9c388448629a6fe868d068c42a488b478ae",
-        {
-            "isCompressed": false,
-            "isPrivkey": true,
-            "chain": "main"
-        }
-    ],
-    [
-        "KwV9KAfwbwt51veZWNscRTeZs9CKpojyu1MsPnaKTF5kz69H1UN2",
-        "07f0803fc5399e773555ab1e8939907e9badacc17ca129e67a2f5f2ff84351dd",
-        {
-            "isCompressed": true,
-            "isPrivkey": true,
-            "chain": "main"
-        }
-    ],
-    [
-        "93N87D6uxSBzwXvpokpzg8FFmfQPmvX4xHoWQe3pLdYpbiwT5YV",
-        "ea577acfb5d1d14d3b7b195c321566f12f87d2b77ea3a53f68df7ebf8604a801",
-        {
-            "isCompressed": false,
-            "isPrivkey": true,
-            "chain": "test"
-        }
-    ],
-    [
-        "cMxXusSihaX58wpJ3tNuuUcZEQGt6DKJ1wEpxys88FFaQCYjku9h",
-        "0b3b34f0958d8a268193a9814da92c3e8b58b4a4378a542863e34ac289cd830c",
-        {
-            "isCompressed": true,
-            "isPrivkey": true,
-            "chain": "test"
-        }
-    ],
-    [
-        "13p1ijLwsnrcuyqcTvJXkq2ASdXqcnEBLE",
-        "76a9141ed467017f043e91ed4c44b4e8dd674db211c4e688ac",
-        {
-            "isPrivkey": false,
-            "chain": "main"
-        }
-    ],
-    [
-        "3ALJH9Y951VCGcVZYAdpA3KchoP9McEj1G",
-        "a9145ece0cadddc415b1980f001785947120acdb36fc87",
-        {
-            "isPrivkey": false,
-            "chain": "main"
-        }
-    ],
-    [
-        "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4",
-        "0014751e76e8199196d454941c45d1b3a323f1433bd6",
-        {
-            "isPrivkey": false,
             "chain": "main",
-            "tryCaseFlip": true
+            "isPrivkey": false
         }
     ],
     [
-        "bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080",
-        "0014751e76e8199196d454941c45d1b3a323f1433bd6",
+        "SWTEL1MagXhx4uHm3JeSQL5Emk5TLJ93mx",
+        "a9146477f98010b0f68a4c7ef76ddb45ac16d4cdc31e87",
         {
-            "isPrivkey": false,
-            "chain": "regtest",
-            "tryCaseFlip": true
+            "chain": "main",
+            "isPrivkey": false
         }
     ],
     [
-        "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7",
-        "00201863143c14c5166804bd19203356da136c985678cd4d27a1b8c6329604903262",
+        "sp9fqfTiFgxTqZpABFDVuofeKC2rvaSVHy",
+        "76a91447fe6f04d48b4e806f5a9c9205987284da71706788ac",
         {
-            "isPrivkey": false,
             "chain": "test",
-            "tryCaseFlip": true
+            "isPrivkey": false
         }
     ],
     [
-        "bc1pw508d6qejxtdg4y5r3zarvary0c5xw7kw508d6qejxtdg4y5r3zarvary0c5xw7k7grplx",
-        "5128751e76e8199196d454941c45d1b3a323f1433bd6751e76e8199196d454941c45d1b3a323f1433bd6",
+        "yWG3eDzwk8ARJUd5wFdfxDTuLWAUK13bW8",
+        "a9146d0ca35c342ac6bf8b9af0c55e81880d5ceb6ce987",
         {
-            "isPrivkey": false,
-            "chain": "main",
-            "tryCaseFlip": true
-        }
-    ],
-    [
-        "bc1sw50qa3jx3s",
-        "6002751e",
-        {
-            "isPrivkey": false,
-            "chain": "main",
-            "tryCaseFlip": true
-        }
-    ],
-    [
-        "bc1zw508d6qejxtdg4y5r3zarvaryvg6kdaj",
-        "5210751e76e8199196d454941c45d1b3a323",
-        {
-            "isPrivkey": false,
-            "chain": "main",
-            "tryCaseFlip": true
-        }
-    ],
-    [
-        "tb1qqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvsesrxh6hy",
-        "0020000000c4a5cad46221b2a187905e5266362b99d5e91c6ce24d165dab93e86433",
-        {
-            "isPrivkey": false,
             "chain": "test",
+            "isPrivkey": false
+        }
+    ],
+    [
+        "swqoi6B2VyWUMEwnhz19mg9bXHvEXFCrid",
+        "76a9149c5e858cf99f73f6d268bed1b0d373adcc915cac88ac",
+        {
+            "chain": "regtest",
+            "isPrivkey": false
+        }
+    ],
+    [
+        "yNxzc9vYDThfkbBETAmgZmPtXfJ5jzTgbD",
+        "a9141d0a26f7cea2813a260bd5b0572149ee5c203bcf87",
+        {
+            "chain": "regtest",
+            "isPrivkey": false
+        }
+    ],
+    [
+        "5JQsweUVF7V243N2qmoJtDjGqhXqPcwViWG961P1hsrAoMsNAnQ",
+        "4e8bde98e8eafd2aa4549cae83a4f8f34143520520a04aa6fc83d21f2ab7d414",
+        {
+            "chain": "main",
+            "isCompressed": false,
+            "isPrivkey": true
+        }
+    ],
+    [
+        "Kwp67juX8N2FB2nUyGtTHaaNma44EMRGKD8QXwhiqUoYhqHXyWjD",
+        "11af77b25d8f0cc693872b1d98d3089b640b009277f379bec3f84d345a6bfeeb",
+        {
+            "chain": "main",
+            "isCompressed": true,
+            "isPrivkey": true
+        }
+    ],
+    [
+        "9YfcMVkqLEScRwBwtkcKnjSZ4PBxB2X1UNarv429L5VYaaPF57S",
+        "fd3c20473f3f9bbfa6c0a52782f9fd97e45cebe31d0db5be794d94cc0d5ec219",
+        {
+            "chain": "test",
+            "isCompressed": false,
+            "isPrivkey": true
+        }
+    ],
+    [
+        "eayy7rq7sAfLvVojG4ruuTVeiaTjHrqqq8pf6UeB8tXRfKbkiLTc",
+        "14fe52ae887c04ffcba5de6e1546358c33dc5baf595c17a935d0de0aa2dd0948",
+        {
+            "chain": "test",
+            "isCompressed": true,
+            "isPrivkey": true
+        }
+    ],
+    [
+        "9Y1S3m5wqzGLCaMKq83P2Vwhm1YXjqjFThbWXVxBi9GMwBWfL4N",
+        "a68c3a11e651e8dfd702f057bd669ca6e5d4f6aa23b2c59de90b708121a138a9",
+        {
+            "chain": "regtest",
+            "isCompressed": false,
+            "isPrivkey": true
+        }
+    ],
+    [
+        "eggLmzomHHvVJi5Zov7FSQbnXazhGpzfvHMQNUeZWbdUSHxQCiGj",
+        "bef335e5700ce9c9ef26126a8c9c4cabed0e59b9cf6b492e62152d364ba1d66a",
+        {
+            "chain": "regtest",
+            "isCompressed": true,
+            "isPrivkey": true
+        }
+    ],
+    [
+        "dgb1q4kn4yzgtpkkd97ctzuutf8wgnv2x3vthtxvexp",
+        "0014ada752090b0dacd2fb0b1738b49dc89b1468b177",
+        {
+            "chain": "main",
+            "isPrivkey": false,
             "tryCaseFlip": true
         }
     ],
     [
-        "bcrt1qqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvseswlauz7",
-        "0020000000c4a5cad46221b2a187905e5266362b99d5e91c6ce24d165dab93e86433",
+        "dgb1qmvpnvkcr8mecfsmc7dwdsrhpvlvzvx32y0eu4xuy3d6t6krev2wqqnh4az",
+        "0020db03365b033ef384c378f35cd80ee167d8261a2a23f3ca9b848b74bd5879629c",
         {
+            "chain": "main",
             "isPrivkey": false,
-            "chain": "regtest",
             "tryCaseFlip": true
+        }
+    ],
+    [
+        "dgb1p3dcq6frp8g",
+        "51028b70",
+        {
+            "chain": "main",
+            "isPrivkey": false,
+            "tryCaseFlip": true
+        }
+    ],
+    [
+        "dgbt1qqq4gp4yg4ukd6pcgpfztcjyu0sq5tjdlfjdsat",
+        "0014002a80d488af2cdd07080a44bc489c7c0145c9bf",
+        {
+            "chain": "test",
+            "isPrivkey": false,
+            "tryCaseFlip": true
+        }
+    ],
+    [
+        "dgbt1qwc8hgqyzzssua65kssh8dwcp6y862q2dmstdx0zsg2szqswtfgyqr43mgp",
+        "0020760f7400821421ceea96842e76bb01d10fa5014ddc16d33c5042a02041cb4a08",
+        {
+            "chain": "test",
+            "isPrivkey": false,
+            "tryCaseFlip": true
+        }
+    ],
+    [
+        "dgbt1z3lfs6xsl5hj6suq8f5wkum6rlsxxuzc8",
+        "52108fd30d1a1fa5e5a870074d1d6e6f43fc",
+        {
+            "chain": "test",
+            "isPrivkey": false,
+            "tryCaseFlip": true
+        }
+    ],
+    [
+        "dgbrt1qhrmuftlr4923x99zv4hpqgz90g9w5lenx9kc90",
+        "0014b8f7c4afe3a9551314a2656e1020457a0aea7f33",
+        {
+            "chain": "regtest",
+            "isPrivkey": false,
+            "tryCaseFlip": true
+        }
+    ],
+    [
+        "dgbrt1qta43sr9asp57rkwr9qzmjddmmrcw5an0lc6m7rlfv0q4mf8ddunqrky7uz",
+        "00205f6b180cbd8069e1d9c32805b935bbd8f0ea766ffe35bf0fe963c15da4ed6f26",
+        {
+            "chain": "regtest",
+            "isPrivkey": false,
+            "tryCaseFlip": true
+        }
+    ],
+    [
+        "dgbrt1svkdtcuxzn5ax22mj967z5dx2dmdrc4w3md7njxtacsnld8xt4ff3rhy782w88zltm0d5f7",
+        "6028659abc70c29d3a652b722ebc2a34ca6eda3c55d1db7d39197dc427f69ccbaa5311dc9e3a9c738beb",
+        {
+            "chain": "regtest",
+            "isPrivkey": false,
+            "tryCaseFlip": true
+        }
+    ],
+    [
+        "D6P9iwS2Whz5vB2Mmt9mrPZHbmr3oBe8fu",
+        "76a9140da09b747205e2ea4ff25265c90d949f59d2ff2288ac",
+        {
+            "chain": "main",
+            "isPrivkey": false
+        }
+    ],
+    [
+        "SNM3fhyJmCD5ECwzysEbCU5B2kdNLZ1F9f",
+        "a9140b8b92e24e45eee7eb89a8c396ab0053643af72487",
+        {
+            "chain": "main",
+            "isPrivkey": false
+        }
+    ],
+    [
+        "sxWD1fzpexwSEWkdqpY8iyf6a9NXtekz29",
+        "76a914a3a1c7ddbc4dcfae0c97f0b814dd79eea52ebf5488ac",
+        {
+            "chain": "test",
+            "isPrivkey": false
+        }
+    ],
+    [
+        "yWAyvHNnRXH2enZ6B7FXY9aE2NKtMwo5RU",
+        "a9146c17734d778b6191516cc2f257aeaff6f8babfb487",
+        {
+            "chain": "test",
+            "isPrivkey": false
+        }
+    ],
+    [
+        "t6bJEV8Fmck4WN2xRSkmx2oVLMRp9iWtMj",
+        "76a914fc5939998d79f163f116b95a0fdbd6eb3fc5c3e388ac",
+        {
+            "chain": "regtest",
+            "isPrivkey": false
+        }
+    ],
+    [
+        "yjVgm3XDSvBJVfRZ77cQYn7fSTVD7jz2cR",
+        "a914fe3aaa3e0af3a8de6913c02b1207175c385f243f87",
+        {
+            "chain": "regtest",
+            "isPrivkey": false
+        }
+    ],
+    [
+        "5J367GdKAsPTKunGfiv5ZWZRxq9N2a8BHoXhsuT5FZLadsF7Tif",
+        "1d11a6eea716f8a976781597231f666a7fb6a3ef2c9d71b47017d68dee008c83",
+        {
+            "chain": "main",
+            "isCompressed": false,
+            "isPrivkey": true
+        }
+    ],
+    [
+        "L2yNtAC2GC4PpxmPi1xHHvWFGuXuST9ECsdehH8FuXfVqAj1DdVs",
+        "aba6ab40a027598bec40df58dfabdbe52a0e79b9b6ec2aca69f9ecf541cf5c49",
+        {
+            "chain": "main",
+            "isCompressed": true,
+            "isPrivkey": true
+        }
+    ],
+    [
+        "9YQf7hWx5MHHormtz7HsbZTcRSWw7i7tHmPiYqNp8Mz2XEim2ab",
+        "db489e50c52deb2b71cb9c153dd916021c1b2f3afaebddda334756711ff1be54",
+        {
+            "chain": "test",
+            "isCompressed": false,
+            "isPrivkey": true
+        }
+    ],
+    [
+        "ebJFVFFKyHSfjaQKSso3nV15sDN7asCDWmC5j7P64bBh92DUsB1R",
+        "1e6605184894337216688461372fe8cda2dd343770a3e033208a328d0109e804",
+        {
+            "chain": "test",
+            "isCompressed": true,
+            "isPrivkey": true
+        }
+    ],
+    [
+        "9YPTe93vjbJx3umA6G6k2KHrq8aSt8xK44bxDWbKX6n7cVVt2vv",
+        "d89055955e08fc084b061d54de656cfd5d3fbe6bd4c1a9cbd418de625d09425d",
+        {
+            "chain": "regtest",
+            "isCompressed": false,
+            "isPrivkey": true
+        }
+    ],
+    [
+        "efVSHAPU6LwdadfLtGYHBR2bayfzwxLSo6CRFBEmDuVEqDndPvg5",
+        "9b80acc2a80413c515d3682d27be3378d539b2342cbc294aed62e225a3961547",
+        {
+            "chain": "regtest",
+            "isCompressed": true,
+            "isPrivkey": true
+        }
+    ],
+    [
+        "dgb1q204z0w4efg356m7l8h4pwk5czt2xwtfs09sr63",
+        "001453ea27bab94a234d6fdf3dea175a9812d4672d30",
+        {
+            "chain": "main",
+            "isPrivkey": false,
+            "tryCaseFlip": true
+        }
+    ],
+    [
+        "dgb1qf0qeh5xwsg7v5mdferht8upzlaxgwhatkqmcyjp07ajyuxkqwxzsf9yukk",
+        "00204bc19bd0ce823cca6da9c8eeb3f022ff4c875fabb03782482ff7644e1ac07185",
+        {
+            "chain": "main",
+            "isPrivkey": false,
+            "tryCaseFlip": true
+        }
+    ],
+    [
+        "dgb1pqxds72pxzz",
+        "5102019b",
+        {
+            "chain": "main",
+            "isPrivkey": false,
+            "tryCaseFlip": true
+        }
+    ],
+    [
+        "dgbt1qv692udpy7htujv9n0xjq7s38pplr94uqmnwalr",
+        "0014668aae3424f5d7c930b379a40f4227087e32d780",
+        {
+            "chain": "test",
+            "isPrivkey": false,
+            "tryCaseFlip": true
+        }
+    ],
+    [
+        "dgbt1qjeg2hap7km3t04myzas5fxs5nwzj53gwd43mxj2w7s5v3lc6m6xqzdu2j4",
+        "00209650abf43eb6e2b7d7641761449a149b852a450e6d63b3494ef428c8ff1ade8c",
+        {
+            "chain": "test",
+            "isPrivkey": false,
+            "tryCaseFlip": true
+        }
+    ],
+    [
+        "dgbt1z2uqynunngenayfv9gvz9m5hefqt6pqyc",
+        "5210570049f2734667d2258543045dd2f948",
+        {
+            "chain": "test",
+            "isPrivkey": false,
+            "tryCaseFlip": true
+        }
+    ],
+    [
+        "dgbrt1qwvmy2v3vhgq8zzxv4n3hfrnaw5v0jhgm7xwjla",
+        "0014733645322cba007108ccace3748e7d7518f95d1b",
+        {
+            "chain": "regtest",
+            "isPrivkey": false,
+            "tryCaseFlip": true
+        }
+    ],
+    [
+        "dgbrt1qdl6cacl6x47eyq3mzaqwssyqavydat0fffymmvdvm0tmgaw0sjuqxml3q5",
+        "00206ff58ee3fa357d92023b1740e84080eb08deade94a49bdb1acdbd7b475cf84b8",
+        {
+            "chain": "regtest",
+            "isPrivkey": false,
+            "tryCaseFlip": true
+        }
+    ],
+    [
+        "dgbrt1sfqy0mgvgtg4hf65e2ycdmw2442ssu054ur4a6maknpw3hzv65p8u9c34fe87m4pyl5q3wd",
+        "60284808fda1885a2b74ea995130ddb955aaa10e3e95e0ebdd6fb6985d1b899aa04fc2e2354e4fedd424",
+        {
+            "chain": "regtest",
+            "isPrivkey": false,
+            "tryCaseFlip": true
+        }
+    ],
+    [
+        "D84mCjUKj9yTBHMHCeZTwcSrgmsw96rfBT",
+        "76a91420169274428cb8f7f9d6748cd01dc1e1041095e388ac",
+        {
+            "chain": "main",
+            "isPrivkey": false
+        }
+    ],
+    [
+        "STp663hHYQTydHuJ7UZXmY2ntXoZ9QZtBr",
+        "a914478174174762e0aa469e32cff6ce07bd7c68a84c87",
+        {
+            "chain": "main",
+            "isPrivkey": false
+        }
+    ],
+    [
+        "skcdZB9apZyik7Q7H3PSJJfy3Lw8aNSvjG",
+        "76a91421374132c749429b8b1df70dcbad867234de6e6288ac",
+        {
+            "chain": "test",
+            "isPrivkey": false
+        }
+    ],
+    [
+        "yNKt5D2z5irUUZViZsLMEwB1LXButmXJPV",
+        "a91416054ec4f8882950be19b956c5c88a404b4266d787",
+        {
+            "chain": "test",
+            "isPrivkey": false
+        }
+    ],
+    [
+        "t5wKjD6mfKSsMaVkFNPqt8f2zTCtFWaXsQ",
+        "76a914f52aaaa70e361eb1c6304487ae3c8a0e937f2ec688ac",
+        {
+            "chain": "regtest",
+            "isPrivkey": false
+        }
+    ],
+    [
+        "yePjGrGjpAPG7yNqPhtpJo8GgVEs4r2M5C",
+        "a914c641a38966d3467944821fdb3bf5ced28f36956787",
+        {
+            "chain": "regtest",
+            "isPrivkey": false
+        }
+    ],
+    [
+        "5K99P9whfEskkPGGnNrFjdmWQaLdRZg6adbAcHcXcyRZKpfxsNe",
+        "ae8456dfaea92b1f531ee8448dfe8e92a7ce6e66418721e6282c2865bbb63430",
+        {
+            "chain": "main",
+            "isCompressed": false,
+            "isPrivkey": true
+        }
+    ],
+    [
+        "L5Xn1K6XobLbBFhLgxj6yEzMecZmmUDHwY9izkPx4kfYTSWcHcGd",
+        "f7fe32077e704196cceee65d2f98b8ec32678e2f907930e45cf420dadb525598",
+        {
+            "chain": "main",
+            "isCompressed": true,
+            "isPrivkey": true
         }
     ]
 ]

--- a/src/test/key_io_tests.cpp
+++ b/src/test/key_io_tests.cpp
@@ -22,7 +22,8 @@ BOOST_FIXTURE_TEST_SUITE(key_io_tests, BasicTestingSetup)
 // Goal: check that parsed keys match test payload
 BOOST_AUTO_TEST_CASE(key_io_valid_parse)
 {
-    UniValue tests = read_json(std::string(json_tests::key_io_valid, json_tests::key_io_valid + sizeof(json_tests::key_io_valid)));
+    std::string input = std::string(json_tests::key_io_valid, json_tests::key_io_valid + sizeof(json_tests::key_io_valid));
+    UniValue tests = read_json(input);
     CKey privkey;
     CTxDestination destination;
     SelectParams(CBaseChainParams::MAIN);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -46,6 +46,7 @@
 
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/thread.hpp>
+#include <boost/bind.hpp>
 
 #if defined(NDEBUG)
 # error "DigiByte cannot be compiled without assertions."

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -17,6 +17,7 @@
 #include <atomic>
 #include <future>
 
+#include <boost/bind.hpp>
 #include <boost/signals2/signal.hpp>
 
 struct MainSignalsInstance {


### PR DESCRIPTION
# DigiByte specific key_io_tests

### What is the intention of this PR?
This PR fixes the `key_io_tests` with DigiByte's specific Network Parameters.

### Description of the changes
The commit https://github.com/SmartArray/digibyte/commit/30d16f85fd08dc31eaa0de04e6ef364c778ad6fb alters the Bitcoin Test Vectors in such a way that they fit DigiByte's implementation (Network Parameters, Address Prefixes, etc.) and result in a 100% integration test rate for the test `key_io_tests`.

### How to verify?
1) Change to the directory src/test
2) Compile the test suite
3) Run it using
```bash
./test_digibyte --run_test=key_io_tests
```