### PR TITLE
test: correct main_tests (subsidy)

### DIFF
--- a/src/test/main_tests.cpp
+++ b/src/test/main_tests.cpp
@@ -12,51 +12,169 @@
 #include <boost/signals2/signal.hpp>
 #include <boost/test/unit_test.hpp>
 
+#define END_OF_SUPPLY_CURVE 110579600
+
+// Set OUTPUT_SUPPLY_SAMPLES_ENABLED to 1 to output
+// sampled Supply-curve data points (SAMPLE_INTERVAL)
+#ifndef OUTPUT_SUPPLY_SAMPLES_ENABLED
+    #define OUTPUT_SUPPLY_SAMPLES_ENABLED 0
+#endif
+
+#ifndef SAMPLE_INTERVAL
+    #define SAMPLE_INTERVAL 100
+#endif
+
+#ifndef WHOLE_COIN
+    #define WHOLE_COIN false
+#endif
+
+#define CALC_COIN(amount) (WHOLE_COIN ? (amount / COIN) : (amount))
+
+#if OUTPUT_SUPPLY_SAMPLES_ENABLED 
+    #define DEBUG(x,y) if (x % SAMPLE_INTERVAL == 0) { \
+        std::cerr << x << ';' << CALC_COIN(y) << std::endl; \
+    }
+#else
+    #define DEBUG(x,y) (void) (x)
+#endif
+
+
 BOOST_FIXTURE_TEST_SUITE(main_tests, TestingSetup)
 
-static void TestBlockSubsidyHalvings(const Consensus::Params& consensusParams)
+static void TestBlockSubsidy(const Consensus::Params& consensusParams, int nMaxBlocks, CAmount* nSumOut)
 {
-    int maxHalvings = 64;
-    CAmount nInitialSubsidy = 50 * COIN;
+    CAmount nSum = 0;
+    CAmount nInitialSubsidy = 72000 * COIN;
 
     CAmount nPreviousSubsidy = nInitialSubsidy * 2; // for height == 0
     BOOST_CHECK_EQUAL(nPreviousSubsidy, nInitialSubsidy * 2);
-    for (int nHalvings = 0; nHalvings < maxHalvings; nHalvings++) {
-        int nHeight = nHalvings * consensusParams.nSubsidyHalvingInterval;
-        CAmount nSubsidy = GetBlockSubsidy(nHeight, consensusParams);
-        BOOST_CHECK(nSubsidy <= nInitialSubsidy);
-        BOOST_CHECK_EQUAL(nSubsidy, nPreviousSubsidy / 2);
-        nPreviousSubsidy = nSubsidy;
-    }
-    BOOST_CHECK_EQUAL(GetBlockSubsidy(maxHalvings * consensusParams.nSubsidyHalvingInterval, consensusParams), 0);
-}
 
-static void TestBlockSubsidyHalvings(int nSubsidyHalvingInterval)
-{
-    Consensus::Params consensusParams;
-    consensusParams.nSubsidyHalvingInterval = nSubsidyHalvingInterval;
-    TestBlockSubsidyHalvings(consensusParams);
+    /* Before first hard fork */
+
+    // 72000 reward for the first 1440 blocks
+    for (int nBlocks = 0; nBlocks < 1440 && nBlocks < consensusParams.nDiffChangeTarget; ++nBlocks)
+    {
+        int nHeight = nBlocks;
+        CAmount nSubsidy = GetBlockSubsidy(nHeight, consensusParams);
+        BOOST_CHECK_EQUAL(nSubsidy, nInitialSubsidy);
+
+        nSum += nSubsidy;
+        DEBUG(nBlocks, nSubsidy);
+    }
+
+    // 16000 rewards until block height 5760
+    for (int nBlocks = 1440; nBlocks < 5760 && nBlocks < consensusParams.nDiffChangeTarget; ++nBlocks)
+    {
+        int nHeight = nBlocks;
+        CAmount nSubsidy = GetBlockSubsidy(nHeight, consensusParams);
+        BOOST_CHECK_EQUAL(nSubsidy, 16000 * COIN);
+
+        nSum += nSubsidy;
+        DEBUG(nBlocks, nSubsidy);
+    }
+
+    // 8000 mining rewards until block height 67,200
+    for (int nBlocks = 5760; nBlocks < consensusParams.nDiffChangeTarget; ++nBlocks)
+    {
+        int nHeight = nBlocks;
+        CAmount nSubsidy = GetBlockSubsidy(nHeight, consensusParams);
+        BOOST_CHECK_EQUAL(nSubsidy, 8000 * COIN);  
+
+        nSum += nSubsidy;
+        DEBUG(nBlocks, nSubsidy);
+    }
+
+    // Dynamic mining rewards from block height 67,200 to block height 400,000 
+    for (int nBlocks = consensusParams.nDiffChangeTarget; nBlocks < consensusParams.alwaysUpdateDiffChangeTarget; ++nBlocks)
+    {
+        int nHeight = nBlocks;
+        CAmount nSubsidy = GetBlockSubsidy(nHeight, consensusParams);
+
+        CAmount nExpectedSubsidy = 8000 * COIN;
+        int nHeightWithinFork = (nHeight - consensusParams.nDiffChangeTarget);
+
+        for (int i = 0; i < (nHeightWithinFork / consensusParams.patchBlockRewardDuration) + 1; ++i) {
+            nExpectedSubsidy -= nExpectedSubsidy / 200; // dec by 0.5%
+        }
+
+        BOOST_CHECK_EQUAL(nSubsidy, nExpectedSubsidy);
+
+        nSum += nSubsidy;
+        DEBUG(nBlocks, nSubsidy);
+    }
+
+    // Updated dynamic mining rewards from block height 400,000 to block height 1,430,000
+    for (int nBlocks = consensusParams.alwaysUpdateDiffChangeTarget; nBlocks < consensusParams.workComputationChangeTarget; ++nBlocks)
+    {
+        int nHeight = nBlocks;
+        CAmount nSubsidy = GetBlockSubsidy(nHeight, consensusParams);
+
+        CAmount nExpectedSubsidy = 2459 * COIN;
+        int nHeightWithinFork = (nHeight - consensusParams.alwaysUpdateDiffChangeTarget);
+
+        for (int i = 0; i < (nHeightWithinFork / consensusParams.patchBlockRewardDuration2) + 1; ++i) {
+            nExpectedSubsidy -= nExpectedSubsidy / 100; // dec by 1% per month
+        }
+
+        BOOST_CHECK_EQUAL(nSubsidy, nExpectedSubsidy);
+
+        nSum += nSubsidy;
+        DEBUG(nBlocks, nSubsidy);
+    }
+
+    // Updated dynamic mining rewards from block height 1,430,000 to max block height (41.6 million)
+    for (int nBlocks = consensusParams.workComputationChangeTarget; nBlocks < nMaxBlocks; ++nBlocks) {
+        int nHeight = nBlocks;
+        CAmount nSubsidy = GetBlockSubsidy(nHeight, consensusParams);
+
+        CAmount nExpectedSubsidy = 2157 * COIN / 2;
+        int nHeightWithinFork = (nHeight - consensusParams.workComputationChangeTarget);
+
+        int nMonths = nHeightWithinFork * BLOCK_TIME_SECONDS / SECONDS_PER_MONTH;
+        pow
+        for (int i = 0; i < nMonths; ++i) {
+            // Decay factor: 98884/100000
+            nExpectedSubsidy *= 98884; 
+            nExpectedSubsidy /= 100000; 
+        }
+
+        if (nExpectedSubsidy < COIN) {
+            nExpectedSubsidy = COIN;
+        }
+
+        BOOST_CHECK_EQUAL(nSubsidy, nExpectedSubsidy);
+
+        nSum += nSubsidy;
+        DEBUG(nBlocks, nSubsidy);
+    }
+
+    CAmount nSubsidy = GetBlockSubsidy(nMaxBlocks, consensusParams);
+    CAmount nExpectedSubsidy = 1 * COIN;
+
+    BOOST_CHECK_EQUAL(nSubsidy, nExpectedSubsidy);
+
+    if (nSumOut != NULL) {
+        *nSumOut = nSum;
+    }
 }
 
 BOOST_AUTO_TEST_CASE(block_subsidy_test)
 {
+    CAmount sum;
     const auto chainParams = CreateChainParams(CBaseChainParams::MAIN);
-    TestBlockSubsidyHalvings(chainParams->GetConsensus()); // As in main
-    TestBlockSubsidyHalvings(150); // As in regtest
-    TestBlockSubsidyHalvings(1000); // Just another interval
-}
+    const auto testChainParams = CreateChainParams(CBaseChainParams::TESTNET);
+    TestBlockSubsidy(chainParams->GetConsensus(), END_OF_SUPPLY_CURVE, &sum); // Mainnet
 
-BOOST_AUTO_TEST_CASE(subsidy_limit_test)
-{
-    const auto chainParams = CreateChainParams(CBaseChainParams::MAIN);
-    CAmount nSum = 0;
-    for (int nHeight = 0; nHeight < 14000000; nHeight += 1000) {
-        CAmount nSubsidy = GetBlockSubsidy(nHeight, chainParams->GetConsensus());
-        BOOST_CHECK(nSubsidy <= 50 * COIN);
-        nSum += nSubsidy * 1000;
-        BOOST_CHECK(MoneyRange(nSum));
-    }
-    BOOST_CHECK_EQUAL(nSum, CAmount{2099999997690000});
+    CAmount nExpectedTotalSupply = 2239167398214795680ULL;
+    BOOST_CHECK_EQUAL(sum, nExpectedTotalSupply);
+
+#if OUTPUT_SUPPLY_SAMPLES_ENABLED
+    std::cout << "(mainnet): MAXIMUM SUPPLY: " << sum << " dgbSATS (" << (sum / COIN) << " DGB)";
+#else
+    // Only perform test on TESTNET too, if we are not
+    // outputting the sampled supply data.
+    TestBlockSubsidy(testChainParams->GetConsensus(), END_OF_SUPPLY_CURVE, NULL); // Testnet
+#endif
 }
 
 static bool ReturnFalse() { return false; }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -46,6 +46,7 @@
 
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/thread.hpp>
+#include <boost/bind.hpp>
 
 #if defined(NDEBUG)
 # error "DigiByte cannot be compiled without assertions."

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -17,6 +17,7 @@
 #include <atomic>
 #include <future>
 
+#include <boost/bind.hpp>
 #include <boost/signals2/signal.hpp>
 
 struct MainSignalsInstance {


### PR DESCRIPTION
# DigiByte specific main_tests (subsidy)

### What is the intention of this PR?
This PR fixes the `main_tests` with DigiByte's specific Supply Curve Parameters.
Unfortunately, there have been many hard forks along the road of DigiByte, and almost all of them seem to have altered the supply parameters, which basically means we can't just loop through the halvings and validate the supply curve.

**Be warned:** This unit test was adapted to check the **whole** supply curve, even if the supply curve itself is erroneous. A new PR which alters the supply curve parameters must also provide an updated `main_tests` unit test.
This test will take some time to run due to the huge number of blocks it iterates through (6-8 min). The new code, in which the supply curve parameters have been altered, needs 6 different loops to test each and every hard fork (starting here: https://github.com/SmartArray/digibyte/blob/1dde1ec334a33e756a0724a3a0c679b16143bc80/src/test/main_tests.cpp#L62)

### Description of the changes
The commit https://github.com/SmartArray/digibyte/commit/5747bb314433a5d47b53936487d9f3863766fc84 updated the `main_tests` unit test in order to test DigiBytes Subsidy.

https://github.com/SmartArray/digibyte/commit/1dde1ec334a33e756a0724a3a0c679b16143bc80 adds a major algorithmical optimization in order to drastically reduce the runtime of this unit test.

### How to verify?
1) Change to the directory src/test
2) Compile the test suite
3) Run it using
```bash
./test_digibyte --run_test=main_tests
```

### Expected outcome
```
$ ./test_digibyte --run_test=main_tests
Running 2 test cases...
*** No errors detected
```

### Remarks
This doesn't fix the issue discussed in https://github.com/DigiByte-Core/digibyte/issues/20