### PR TITLE
test: correct denialofservice_tests

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -46,6 +46,7 @@
 
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/thread.hpp>
+#include <boost/bind.hpp>
 
 #if defined(NDEBUG)
 # error "DigiByte cannot be compiled without assertions."

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -17,6 +17,7 @@
 #include <atomic>
 #include <future>
 
+#include <boost/bind.hpp>
 #include <boost/signals2/signal.hpp>
 
 struct MainSignalsInstance {


### PR DESCRIPTION
# DigiByte specific denialofservice_tests

### What is the intention of this PR?
This PR fixes the `denialofservice_tests` with DigiByte's specific Block Time Configuration.

### Description of the changes
The commit https://github.com/SmartArray/digibyte/commit/a9032a4545b0bfa43e3d1774ccc0a9713779500a updated the `denialofservice_tests` unit test in order to test DigiBytes Stability against Denial Of Service Attacks.

### How to verify?
1) Change to the directory src/test
2) Compile the test suite
3) Run it using
```bash
./test_digibyte --run_test= denialofservice_tests
```

### Expected outcome
```
$ ./test_digibyte --run_test=denialofservice_tests                   
Running 6 test cases...

*** No errors detected
```