### PR TITLE
test: correct miner_tests

### DIFF
--- a/contrib/testgen/miner_gen.cpp
+++ b/contrib/testgen/miner_gen.cpp
@@ -1,0 +1,56 @@
+    pblocktemplate->block.hashPrevBlock = uint256S("7497ea1b465eb39f1c8f507bc877078fe016d6fcb6dfad3a64c98dcc6e1e8496");
+
+    while(true) {
+        CBlock *pblock = &pblocktemplate->block; // pointer for convenience
+        std::cout << pblock->hashPrevBlock.ToString() << std::endl;
+        std::cout << chainActive.Tip()->GetBlockHash().ToString() << std::endl;
+        std::cout << "H:" << chainActive.Tip()->nHeight << std::endl;
+
+        pblock->nVersion = 1;
+        pblock->nTime = chainActive.Tip()->GetMedianTimePast()+1;
+        // pblock->nBits = UintToArith256(uint256S("7ffff00000000000000000000000000000000000000000000000000000000000")).GetCompact();
+    //       CMutableTransaction txCoinbase(*pblock->vtx[0]);
+        bool processBlock = false;
+        unsigned int a = 17000000;
+
+        while (!processBlock) {
+            pblock->nNonce = a++;
+            if(a % 100000 == 0) {
+                std::cout << "at count " << a << std::endl;
+            }
+
+            for(int j=1; j<7; j++) {
+        //            CBlock *pblock = &pblocktemplate->block; // pointer for convenience
+        //            pblock->nVersion = 1;
+        //            pblock->nTime = chainActive.Tip()->GetMedianTimePast()+1;
+                CMutableTransaction txCoinbase(*pblock->vtx[0]);
+                txCoinbase.nVersion = 1;
+                txCoinbase.vin[0].scriptSig = CScript();
+                txCoinbase.vin[0].scriptSig.push_back(j); //blockinfo[i].extranonce);
+                txCoinbase.vin[0].scriptSig.push_back(chainActive.Height());
+                txCoinbase.vout.resize(1); // Ignore the (optional) segwit commitment added by CreateNewBlock (as the hardcoded nonces don't account for this)
+                txCoinbase.vout[0].scriptPubKey = CScript();
+                pblock->vtx[0] = MakeTransactionRef(std::move(txCoinbase));
+                if (txFirst.size() == 0)
+                    baseheight = chainActive.Height();
+                if (txFirst.size() < 4)
+                    txFirst.push_back(pblock->vtx[0]);
+                pblock->hashMerkleRoot = BlockMerkleRoot(*pblock);
+                //pblock->nNonce = blockinfo[i].nonce;
+                std::shared_ptr<const CBlock> shared_pblock = std::make_shared<const CBlock>(*pblock);
+                processBlock = ProcessNewBlock(chainparams, shared_pblock, true, nullptr);
+                //BOOST_CHECK(processBlock);
+                if(processBlock) {
+                      std::cout << "nounce is " << shared_pblock->nNonce << std::endl;
+                    std::cout << "extra nounce is " << j << std::endl;
+                    break;
+                }
+            }
+        }
+        //  std::shared_ptr<const CBlock> shared_pblock = std::make_shared<const CBlock>(*pblock);
+        //  bool processBlock = ProcessNewBlock(chainparams, shared_pblock, true, nullptr);
+        //   BOOST_CHECK(ProcessNewBlock(chainparams, shared_pblock, true, nullptr));
+        pblock->hashPrevBlock = pblock->GetHash();
+    }
+
+    return;

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -375,7 +375,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
 
     // subsidy changing
     int nHeight = chainActive.Height();
-    std::cout << "nHeight: " << nHeight << std::endl;
+    
     // Create an actual 209999-long block chain (without valid blocks).
     while (chainActive.Tip()->nHeight < 209999) {
         CBlockIndex* prev = chainActive.Tip();

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -1,5 +1,5 @@
 // Copyright (c) 2009-2019 The Bitcoin Core developers
-// Copyright (c) 2014-2019 The DigiByte Core developers
+// Copyright (c) 2014-2021 The DigiByte Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -53,34 +53,39 @@ struct {
     unsigned char extranonce;
     unsigned int nonce;
 } blockinfo[] = {
-    {4, 0xa4a3e223}, {2, 0x15c32f9e}, {1, 0x0375b547}, {1, 0x7004a8a5},
-    {2, 0xce440296}, {2, 0x52cfe198}, {1, 0x77a72cd0}, {2, 0xbb5d6f84},
-    {2, 0x83f30c2c}, {1, 0x48a73d5b}, {1, 0xef7dcd01}, {2, 0x6809c6c4},
-    {2, 0x0883ab3c}, {1, 0x087bbbe2}, {2, 0x2104a814}, {2, 0xdffb6daa},
-    {1, 0xee8a0a08}, {2, 0xba4237c1}, {1, 0xa70349dc}, {1, 0x344722bb},
-    {3, 0xd6294733}, {2, 0xec9f5c94}, {2, 0xca2fbc28}, {1, 0x6ba4f406},
-    {2, 0x015d4532}, {1, 0x6e119b7c}, {2, 0x43e8f314}, {2, 0x27962f38},
-    {2, 0xb571b51b}, {2, 0xb36bee23}, {2, 0xd17924a8}, {2, 0x6bc212d9},
-    {1, 0x630d4948}, {2, 0x9a4c4ebb}, {2, 0x554be537}, {1, 0xd63ddfc7},
-    {2, 0xa10acc11}, {1, 0x759a8363}, {2, 0xfb73090d}, {1, 0xe82c6a34},
-    {1, 0xe33e92d7}, {3, 0x658ef5cb}, {2, 0xba32ff22}, {5, 0x0227a10c},
-    {1, 0xa9a70155}, {5, 0xd096d809}, {1, 0x37176174}, {1, 0x830b8d0f},
-    {1, 0xc6e3910e}, {2, 0x823f3ca8}, {1, 0x99850849}, {1, 0x7521fb81},
-    {1, 0xaacaabab}, {1, 0xd645a2eb}, {5, 0x7aea1781}, {5, 0x9d6e4b78},
-    {1, 0x4ce90fd8}, {1, 0xabdc832d}, {6, 0x4a34f32a}, {2, 0xf2524c1c},
-    {2, 0x1bbeb08a}, {1, 0xad47f480}, {1, 0x9f026aeb}, {1, 0x15a95049},
-    {2, 0xd1cb95b2}, {2, 0xf84bbda5}, {1, 0x0fa62cd1}, {1, 0xe05f9169},
-    {1, 0x78d194a9}, {5, 0x3e38147b}, {5, 0x737ba0d4}, {1, 0x63378e10},
-    {1, 0x6d5f91cf}, {2, 0x88612eb8}, {2, 0xe9639484}, {1, 0xb7fabc9d},
-    {2, 0x19b01592}, {1, 0x5a90dd31}, {2, 0x5bd7e028}, {2, 0x94d00323},
-    {1, 0xa9b9c01a}, {1, 0x3a40de61}, {1, 0x56e7eec7}, {5, 0x859f7ef6},
-    {1, 0xfd8e5630}, {1, 0x2b0c9f7f}, {1, 0xba700e26}, {1, 0x7170a408},
-    {1, 0x70de86a8}, {1, 0x74d64cd5}, {1, 0x49e738a1}, {2, 0x6910b602},
-    {0, 0x643c565f}, {1, 0x54264b3f}, {2, 0x97ea6396}, {2, 0x55174459},
-    {2, 0x03e8779a}, {1, 0x98f34d8f}, {1, 0xc07b2b07}, {1, 0xdfe29668},
-    {1, 0x3141c7c1}, {1, 0xb3b595f4}, {1, 0x735abf08}, {5, 0x623bfbce},
-    {2, 0xd351e722}, {1, 0xf4ca48c9}, {1, 0x5b19c670}, {1, 0xa164bf0e},
-    {2, 0xbbbeb305}, {2, 0xfe1c810a},
+    {6, 17069655}, {5, 17005807}, {3, 17104788}, {2, 17018511},
+    {4, 17002289}, {2, 17031872}, {3, 17217824}, {3, 17392029},
+    {3, 17132904}, {4, 17295494}, {2, 17106060}, {2, 17122061},
+    {3, 17168597}, {2, 17080811}, {5, 17336605}, {2, 17016588},
+    {3, 17131330}, {5, 17022216}, {4, 17063738}, {5, 17111047},
+    {6, 17103113}, {5, 17044822}, {1, 17291116}, {2, 17146373},
+    {1, 17018968}, {6, 17196421}, {4, 17227889}, {2, 17053482},
+    {3, 17112617}, {4, 17132557}, {6, 17148920}, {3, 17034281},
+    {5, 17916371}, {6, 17014566}, {3, 17079850}, {2, 17123491},
+    {5, 17426925}, {4, 17208585}, {1, 17003919}, {5, 17583243},
+    {6, 17063826}, {4, 17016670}, {3, 17383922}, {4, 17014999},
+    {1, 17059546}, {3, 17140899}, {5, 17086887}, {2, 17067888},
+    {4, 17153046}, {4, 17156194}, {5, 17067760}, {4, 17045640},
+    {5, 17036048}, {4, 17026527}, {3, 17210999}, {6, 17048021},
+    {1, 17032815}, {2, 17019910}, {6, 17056926}, {4, 17535571},
+    {4, 17331417}, {3, 17044631}, {1, 17006590}, {1, 17216776},
+    {4, 17286402}, {1, 17360551}, {3, 17001314}, {5, 17304096},
+    {3, 17318425}, {6, 17323330}, {5, 17103733}, {3, 17298021},
+    {2, 17010320}, {1, 17229603}, {6, 17129780}, {1, 17134717},
+    {2, 17389955}, {5, 17026290}, {6, 17168863}, {5, 17027916},
+    {4, 17127427}, {5, 17095206}, {1, 17666291}, {2, 17044212},
+    {5, 17260045}, {2, 17139925}, {2, 17073229}, {6, 17079099},
+    {6, 17000303}, {1, 17118443}, {6, 17015501}, {5, 17028977},
+    {2, 17233841}, {4, 17022131}, {5, 17115489}, {1, 17174324},
+    {5, 17015562}, {2, 17036612}, {6, 17046047}, {3, 17069896},
+    {1, 17066558}, {5, 17418052}, {1, 17095816}, {5, 17694800},
+    {6, 17197365}, {4, 17013904}, {4, 17008418}, {2, 17080399},
+    {5, 17098279}, {1, 17358100}, {5, 17034203}, {5, 17732840},
+    {2, 17322693}, {6, 17918728}, {6, 17018174}, {6, 17043893},
+    {5, 17120690}, {2, 17166407}, {3, 17259491}, {5, 17311794},
+    {1, 17150249}, {2, 17063136}, {2, 17293003}, {6, 17359996},
+    {3, 17307334}, {2, 17478737}, {3, 17263283}, {5, 17011240},
+    {5, 17128416}, {3, 17370203}, {4, 17036854}, {2, 17026802}, 
 };
 
 static CBlockIndex CreateBlockIndex(int nHeight)
@@ -130,7 +135,7 @@ static void TestPackageSelection(const CChainParams& chainparams, const CScript&
     uint256 hashHighFeeTx = tx.GetHash();
     mempool.addUnchecked(hashHighFeeTx, entry.Fee(50000).Time(GetTime()).SpendsCoinbase(false).FromTx(tx));
 
-    std::unique_ptr<CBlockTemplate> pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey,2);
+    std::unique_ptr<CBlockTemplate> pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey, ALGO_SCRYPT);
     BOOST_CHECK(pblocktemplate->block.vtx[1]->GetHash() == hashParentTx);
     BOOST_CHECK(pblocktemplate->block.vtx[2]->GetHash() == hashHighFeeTx);
     BOOST_CHECK(pblocktemplate->block.vtx[3]->GetHash() == hashMediumFeeTx);
@@ -150,7 +155,7 @@ static void TestPackageSelection(const CChainParams& chainparams, const CScript&
     tx.vout[0].nValue = 5000000000LL - 1000 - 50000 - feeToUse;
     uint256 hashLowFeeTx = tx.GetHash();
     mempool.addUnchecked(hashLowFeeTx, entry.Fee(feeToUse).FromTx(tx));
-    pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey,2);
+    pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey, ALGO_SCRYPT);
     // Verify that the free tx and the low fee tx didn't get selected
     for (size_t i=0; i<pblocktemplate->block.vtx.size(); ++i) {
         BOOST_CHECK(pblocktemplate->block.vtx[i]->GetHash() != hashFreeTx);
@@ -164,7 +169,7 @@ static void TestPackageSelection(const CChainParams& chainparams, const CScript&
     tx.vout[0].nValue -= 2; // Now we should be just over the min relay fee
     hashLowFeeTx = tx.GetHash();
     mempool.addUnchecked(hashLowFeeTx, entry.Fee(feeToUse+2).FromTx(tx));
-    pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey,2);
+    pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey, ALGO_SCRYPT);
     BOOST_CHECK(pblocktemplate->block.vtx[4]->GetHash() == hashFreeTx);
     BOOST_CHECK(pblocktemplate->block.vtx[5]->GetHash() == hashLowFeeTx);
 
@@ -185,7 +190,7 @@ static void TestPackageSelection(const CChainParams& chainparams, const CScript&
     tx.vout[0].nValue = 5000000000LL - 100000000 - feeToUse;
     uint256 hashLowFeeTx2 = tx.GetHash();
     mempool.addUnchecked(hashLowFeeTx2, entry.Fee(feeToUse).SpendsCoinbase(false).FromTx(tx));
-    pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey,2);
+    pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey, ALGO_SCRYPT);
 
     // Verify that this tx isn't selected.
     for (size_t i=0; i<pblocktemplate->block.vtx.size(); ++i) {
@@ -198,7 +203,7 @@ static void TestPackageSelection(const CChainParams& chainparams, const CScript&
     tx.vin[0].prevout.n = 1;
     tx.vout[0].nValue = 100000000 - 10000; // 10k satoshi fee
     mempool.addUnchecked(tx.GetHash(), entry.Fee(10000).FromTx(tx));
-    pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey,2);
+    pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey, ALGO_SCRYPT);
     BOOST_CHECK(pblocktemplate->block.vtx[8]->GetHash() == hashLowFeeTx2);
 }
 
@@ -208,6 +213,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     // Note that by default, these tests run with size accounting enabled.
     const auto chainParams = CreateChainParams(CBaseChainParams::MAIN);
     const CChainParams& chainparams = *chainParams;
+
     CScript scriptPubKey = CScript() << ParseHex("04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5f") << OP_CHECKSIG;
     std::unique_ptr<CBlockTemplate> pblocktemplate;
     CMutableTransaction tx;
@@ -220,7 +226,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     fCheckpointsEnabled = false;
 
     // Simple block creation, nothing special yet:
-    BOOST_CHECK(pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey,2));
+    BOOST_CHECK(pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey, ALGO_SCRYPT));
 
     // We can't make transactions until we have inputs
     // Therefore, load 100 blocks :)
@@ -257,7 +263,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     LOCK(::mempool.cs);
 
     // Just to make sure we can still make simple blocks
-    BOOST_CHECK(pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey,2));
+    BOOST_CHECK(pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey, ALGO_SCRYPT));
 
     const CAmount BLOCKSUBSIDY = 50*COIN;
     const CAmount LOWFEE = CENT;
@@ -282,7 +288,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
         tx.vin[0].prevout.hash = hash;
     }
 
-    BOOST_CHECK_EXCEPTION(AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey,2), std::runtime_error, HasReason("bad-blk-sigops"));
+    BOOST_CHECK_EXCEPTION(AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey, ALGO_SCRYPT), std::runtime_error, HasReason("bad-blk-sigops"));
     mempool.clear();
 
     tx.vin[0].prevout.hash = txFirst[0]->GetHash();
@@ -296,7 +302,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
         mempool.addUnchecked(hash, entry.Fee(LOWFEE).Time(GetTime()).SpendsCoinbase(spendsCoinbase).SigOpsCost(80).FromTx(tx));
         tx.vin[0].prevout.hash = hash;
     }
-    BOOST_CHECK(pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey,2));
+    BOOST_CHECK(pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey, ALGO_SCRYPT));
     mempool.clear();
 
     // block size > limit
@@ -316,13 +322,13 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
         mempool.addUnchecked(hash, entry.Fee(LOWFEE).Time(GetTime()).SpendsCoinbase(spendsCoinbase).FromTx(tx));
         tx.vin[0].prevout.hash = hash;
     }
-    BOOST_CHECK(pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey,2));
+    BOOST_CHECK(pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey, ALGO_SCRYPT));
     mempool.clear();
 
     // orphan in mempool, template creation fails
     hash = tx.GetHash();
     mempool.addUnchecked(hash, entry.Fee(LOWFEE).Time(GetTime()).FromTx(tx));
-    BOOST_CHECK_EXCEPTION(AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey,2), std::runtime_error, HasReason("bad-txns-inputs-missingorspent"));
+    BOOST_CHECK_EXCEPTION(AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey, ALGO_SCRYPT), std::runtime_error, HasReason("bad-txns-inputs-missingorspent"));
     mempool.clear();
 
     // child with higher feerate than parent
@@ -339,7 +345,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     tx.vout[0].nValue = tx.vout[0].nValue+BLOCKSUBSIDY-HIGHERFEE; //First txn output + fresh coinbase - new txn fee
     hash = tx.GetHash();
     mempool.addUnchecked(hash, entry.Fee(HIGHERFEE).Time(GetTime()).SpendsCoinbase(true).FromTx(tx));
-    BOOST_CHECK(pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey,2));
+    BOOST_CHECK(pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey, ALGO_SCRYPT));
     mempool.clear();
 
     // coinbase in mempool, template creation fails
@@ -351,7 +357,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     // give it a fee so it'll get mined
     mempool.addUnchecked(hash, entry.Fee(LOWFEE).Time(GetTime()).SpendsCoinbase(false).FromTx(tx));
     // Should throw bad-cb-multiple
-    BOOST_CHECK_EXCEPTION(AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey,2), std::runtime_error, HasReason("bad-cb-multiple"));
+    BOOST_CHECK_EXCEPTION(AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey, ALGO_SCRYPT), std::runtime_error, HasReason("bad-cb-multiple"));
     mempool.clear();
 
     // double spend txn pair in mempool, template creation fails
@@ -364,23 +370,25 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     tx.vout[0].scriptPubKey = CScript() << OP_2;
     hash = tx.GetHash();
     mempool.addUnchecked(hash, entry.Fee(HIGHFEE).Time(GetTime()).SpendsCoinbase(true).FromTx(tx));
-    BOOST_CHECK_EXCEPTION(AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey,2), std::runtime_error, HasReason("bad-txns-inputs-missingorspent"));
+    BOOST_CHECK_EXCEPTION(AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey, ALGO_SCRYPT), std::runtime_error, HasReason("bad-txns-inputs-missingorspent"));
     mempool.clear();
 
     // subsidy changing
     int nHeight = chainActive.Height();
+    std::cout << "nHeight: " << nHeight << std::endl;
     // Create an actual 209999-long block chain (without valid blocks).
     while (chainActive.Tip()->nHeight < 209999) {
         CBlockIndex* prev = chainActive.Tip();
         CBlockIndex* next = new CBlockIndex();
         next->phashBlock = new uint256(InsecureRand256());
         pcoinsTip->SetBestBlock(next->GetBlockHash());
+        next->nVersion |= BLOCK_VERSION_SCRYPT;
         next->pprev = prev;
         next->nHeight = prev->nHeight + 1;
         next->BuildSkip();
         chainActive.SetTip(next);
     }
-    BOOST_CHECK(pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey, 2));
+    BOOST_CHECK(pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey, ALGO_SCRYPT));
     // Extend to a 210000-long block chain.
     while (chainActive.Tip()->nHeight < 210000) {
         CBlockIndex* prev = chainActive.Tip();
@@ -392,7 +400,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
         next->BuildSkip();
         chainActive.SetTip(next);
     }
-    BOOST_CHECK(pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey,2));
+    BOOST_CHECK(pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey, ALGO_SCRYPT));
 
     // invalid p2sh txn in mempool, template creation fails
     tx.vin[0].prevout.hash = txFirst[0]->GetHash();
@@ -409,7 +417,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     hash = tx.GetHash();
     mempool.addUnchecked(hash, entry.Fee(LOWFEE).Time(GetTime()).SpendsCoinbase(false).FromTx(tx));
     // Should throw block-validation-failed
-    BOOST_CHECK_EXCEPTION(AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey,2), std::runtime_error, HasReason("block-validation-failed"));
+    BOOST_CHECK_EXCEPTION(AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey, ALGO_SCRYPT), std::runtime_error, HasReason("block-validation-failed"));
     mempool.clear();
 
     // Delete the dummy blocks again.
@@ -497,7 +505,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     tx.vin[0].nSequence = CTxIn::SEQUENCE_LOCKTIME_TYPE_FLAG | 1;
     BOOST_CHECK(!TestSequenceLocks(tx, flags)); // Sequence locks fail
 
-    BOOST_CHECK(pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey, 2));
+    BOOST_CHECK(pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey, ALGO_SCRYPT));
 
     // None of the of the absolute height/time locked tx should have made
     // it into the template because we still check IsFinalTx in CreateNewBlock,
@@ -510,7 +518,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     chainActive.Tip()->nHeight++;
     SetMockTime(chainActive.Tip()->GetMedianTimePast() + 1);
 
-    BOOST_CHECK(pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey, 2));
+    BOOST_CHECK(pblocktemplate = AssemblerForTest(chainparams).CreateNewBlock(scriptPubKey, ALGO_SCRYPT));
     BOOST_CHECK_EQUAL(pblocktemplate->block.vtx.size(), 5U);
 
     chainActive.Tip()->nHeight--;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -46,6 +46,7 @@
 
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/thread.hpp>
+#include <boost/bind.hpp>
 
 #if defined(NDEBUG)
 # error "DigiByte cannot be compiled without assertions."

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -17,6 +17,7 @@
 #include <atomic>
 #include <future>
 
+#include <boost/bind.hpp>
 #include <boost/signals2/signal.hpp>
 
 struct MainSignalsInstance {


### PR DESCRIPTION
# DigiByte specific miner_tests

### What is the intention of this PR?
This PR fixes the `miner_tests` with DigiByte's specific Mining Parameters.
Unfortunately, this one required a big custom-made mining script and additional hours of mining in order to generate the test vectors. If something is wrong we have to regenerate those, but on my machines the test is working great so far.

### Description of the changes
The commit https://github.com/SmartArray/digibyte/commit/56f829f1c423b7f22646746247eec0329f7af8be adds a custom code snipped to `contrib/testgen` and updates the `miner_tests` unit test with the test vectors generated using that code snipped. Furthermore, it fixes a bunch of other issues in order to have 100% coverage.

https://github.com/SmartArray/digibyte/commit/30330b2d7b01b1e2f9eac2356c37fe7631d43d30 removes a debug statement.

### How to verify?
1) Change to the directory src/test
2) Compile the test suite
3) Run it using
```bash
./test_digibyte --run_test=miner_tests
```

### Expected outcome
```
$ ./test_digibyte --run_test=miner_tests                            
Running 1 test case...

*** No errors detected
```