### PR TITLE
test: correct pow_tests

### DIFF
--- a/src/test/pow_tests.cpp
+++ b/src/test/pow_tests.cpp
@@ -35,7 +35,7 @@ BOOST_AUTO_TEST_CASE(get_next_work_pow_limit)
     pindexLast.nHeight = 2015;
     pindexLast.nTime = 1233061996;  // Block #2015
     pindexLast.nBits = 0x1d00ffff;
-    BOOST_CHECK_EQUAL(CalculateNextWorkRequired(&pindexLast, nLastRetargetTime, chainParams->GetConsensus()), 0x1d00ffffU);
+    BOOST_CHECK_EQUAL(CalculateNextWorkRequired(&pindexLast, nLastRetargetTime, chainParams->GetConsensus()), 0x1D01B304U);
 }
 
 /* Test the constraint on the lower bound for actual time taken */
@@ -66,12 +66,21 @@ BOOST_AUTO_TEST_CASE(GetBlockProofEquivalentTime_test)
 {
     const auto chainParams = CreateChainParams(CBaseChainParams::MAIN);
     std::vector<CBlockIndex> blocks(10000);
+
     for (int i = 0; i < 10000; i++) {
         blocks[i].pprev = i ? &blocks[i - 1] : nullptr;
         blocks[i].nHeight = i;
+        blocks[i].nVersion = 1;
         blocks[i].nTime = 1269211443 + i * chainParams->GetConsensus().nPowTargetSpacing;
         blocks[i].nBits = 0x207fffff; /* target 0x7fffff000... */
         blocks[i].nChainWork = i ? blocks[i - 1].nChainWork + GetBlockProof(blocks[i - 1]) : arith_uint256(0);
+
+        // Create random block hash
+        const uint256 randomhash = GetRandHash();
+        uint256* ptr = new uint256();
+        *ptr = randomhash;
+
+        blocks[i].phashBlock = ptr;
     }
 
     for (int j = 0; j < 1000; j++) {

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -46,6 +46,7 @@
 
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/thread.hpp>
+#include <boost/bind.hpp>
 
 #if defined(NDEBUG)
 # error "DigiByte cannot be compiled without assertions."

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -17,6 +17,7 @@
 #include <atomic>
 #include <future>
 
+#include <boost/bind.hpp>
 #include <boost/signals2/signal.hpp>
 
 struct MainSignalsInstance {


### PR DESCRIPTION
# DigiByte specific pow_tests

### What is the intention of this PR?
This PR fixes the `pow_tests` with DigiByte's specific PoW Implementation.

### Description of the changes
The commit https://github.com/SmartArray/digibyte/commit/ae74c4deabc1cb6088ed30614bb8e51866705aeb updated the `pow_tests` unit test in order to test DigiBytes Proof Of Work.

### How to verify?
1) Change to the directory src/test
2) Compile the test suite
3) Run it using
```bash
./test_digibyte --run_test=pow_tests
```

### Expected outcome
```
$ ./test_digibyte --run_test=pow_tests
Running 5 test cases...
*** No errors detected
```