### PR TITLE
test: correct versionbits_test

### DIFF
--- a/src/test/versionbits_tests.cpp
+++ b/src/test/versionbits_tests.cpp
@@ -272,56 +272,56 @@ BOOST_AUTO_TEST_CASE(versionbits_computeblockversion)
     // Before MedianTimePast of the chain has crossed nStartTime, the bit
     // should not be set.
     CBlockIndex *lastBlock = nullptr;
-    lastBlock = firstChain.Mine(2016, nTime, VERSIONBITS_LAST_OLD_BLOCK_VERSION).Tip();
-    BOOST_CHECK_EQUAL(ComputeBlockVersion(lastBlock, mainnetParams, 2) & (1<<bit), 0);
+    lastBlock = firstChain.Mine(mainnetParams.nMinerConfirmationWindow, nTime, ALGO_SCRYPT).Tip();
+    BOOST_CHECK_EQUAL(ComputeBlockVersion(lastBlock, mainnetParams, ALGO_SCRYPT) & (1<<bit), 0);
 
-    // Mine 2011 more blocks at the old time, and check that CBV isn't setting the bit yet.
-    for (int i=1; i<2012; i++) {
-        lastBlock = firstChain.Mine(2016+i, nTime, VERSIONBITS_LAST_OLD_BLOCK_VERSION).Tip();
-        // This works because VERSIONBITS_LAST_OLD_BLOCK_VERSION happens
+    // Mine more blocks (4 less than the adjustment period) at the old time, and check that CBV isn't setting the bit yet.
+    for (uint32_t i = 1; i < mainnetParams.nMinerConfirmationWindow - 4; i++) {
+        lastBlock = firstChain.Mine(mainnetParams.nMinerConfirmationWindow + i, nTime, ALGO_SCRYPT).Tip();
+        // This works because ALGO_SCRYPT happens
         // to be 4, and the bit we're testing happens to be bit 28.
-        BOOST_CHECK_EQUAL(ComputeBlockVersion(lastBlock, mainnetParams, 2) & (1<<bit), 0);
+        BOOST_CHECK_EQUAL(ComputeBlockVersion(lastBlock, mainnetParams, ALGO_SCRYPT) & (1<<bit), 0);
     }
     // Now mine 5 more blocks at the start time -- MTP should not have passed yet, so
     // CBV should still not yet set the bit.
     nTime = nStartTime;
-    for (int i=2012; i<=2016; i++) {
-        lastBlock = firstChain.Mine(2016+i, nTime, VERSIONBITS_LAST_OLD_BLOCK_VERSION).Tip();
-        BOOST_CHECK_EQUAL(ComputeBlockVersion(lastBlock, mainnetParams, 2) & (1<<bit), 0);
+    for (uint32_t i = mainnetParams.nMinerConfirmationWindow - 4; i <= mainnetParams.nMinerConfirmationWindow; i++) {
+        lastBlock = firstChain.Mine(mainnetParams.nMinerConfirmationWindow + i, nTime, ALGO_SCRYPT).Tip();
+        BOOST_CHECK_EQUAL(ComputeBlockVersion(lastBlock, mainnetParams, ALGO_SCRYPT) & (1<<bit), 0);
     }
 
     // Advance to the next period and transition to STARTED,
-    lastBlock = firstChain.Mine(6048, nTime, VERSIONBITS_LAST_OLD_BLOCK_VERSION).Tip();
+    lastBlock = firstChain.Mine(mainnetParams.nMinerConfirmationWindow * 3, nTime, ALGO_SCRYPT).Tip();
     // so ComputeBlockVersion should now set the bit,
-    BOOST_CHECK((ComputeBlockVersion(lastBlock, mainnetParams, 2) & (1<<bit)) != 0);
+    BOOST_CHECK((ComputeBlockVersion(lastBlock, mainnetParams, ALGO_SCRYPT) & (1<<bit)) != 0);
     // and should also be using the VERSIONBITS_TOP_BITS.
-    BOOST_CHECK_EQUAL(ComputeBlockVersion(lastBlock, mainnetParams, 2) & VERSIONBITS_TOP_MASK, VERSIONBITS_TOP_BITS);
+    BOOST_CHECK_EQUAL(ComputeBlockVersion(lastBlock, mainnetParams, ALGO_SCRYPT) & VERSIONBITS_TOP_MASK, VERSIONBITS_TOP_BITS);
 
     // Check that ComputeBlockVersion will set the bit until nTimeout
     nTime += 600;
-    int blocksToMine = 4032; // test blocks for up to 2 time periods
-    int nHeight = 6048;
+    uint32_t blocksToMine = mainnetParams.nMinerConfirmationWindow * 2; // test blocks for up to 2 time periods
+    uint32_t nHeight = mainnetParams.nMinerConfirmationWindow * 3;
     // These blocks are all before nTimeout is reached.
     while (nTime < nTimeout && blocksToMine > 0) {
-        lastBlock = firstChain.Mine(nHeight+1, nTime, VERSIONBITS_LAST_OLD_BLOCK_VERSION).Tip();
-        BOOST_CHECK((ComputeBlockVersion(lastBlock, mainnetParams, 2) & (1<<bit)) != 0);
-        BOOST_CHECK_EQUAL(ComputeBlockVersion(lastBlock, mainnetParams, 2) & VERSIONBITS_TOP_MASK, VERSIONBITS_TOP_BITS);
+        lastBlock = firstChain.Mine(nHeight+1, nTime, ALGO_SCRYPT).Tip();
+        BOOST_CHECK((ComputeBlockVersion(lastBlock, mainnetParams, ALGO_SCRYPT) & (1<<bit)) != 0);
+        BOOST_CHECK_EQUAL(ComputeBlockVersion(lastBlock, mainnetParams, ALGO_SCRYPT) & VERSIONBITS_TOP_MASK, VERSIONBITS_TOP_BITS);
         blocksToMine--;
         nTime += 600;
         nHeight += 1;
     }
 
-    nTime = nTimeout;
     // FAILED is only triggered at the end of a period, so CBV should be setting
     // the bit until the period transition.
-    for (int i=0; i<2015; i++) {
-        lastBlock = firstChain.Mine(nHeight+1, nTime, VERSIONBITS_LAST_OLD_BLOCK_VERSION).Tip();
-        BOOST_CHECK((ComputeBlockVersion(lastBlock, mainnetParams, 2) & (1<<bit)) != 0);
-        nHeight += 1;
+    for (uint32_t i = nHeight; i < mainnetParams.nMinerConfirmationWindow * 5; i++) {
+        lastBlock = firstChain.Mine(i, nTime, ALGO_SCRYPT).Tip();
+        BOOST_CHECK((ComputeBlockVersion(lastBlock, mainnetParams, ALGO_SCRYPT) & (1<<bit)) != 0);
     }
+
     // The next block should trigger no longer setting the bit.
-    lastBlock = firstChain.Mine(nHeight+1, nTime, VERSIONBITS_LAST_OLD_BLOCK_VERSION).Tip();
-    BOOST_CHECK_EQUAL(ComputeBlockVersion(lastBlock, mainnetParams, 2) & (1<<bit), 0);
+    nHeight = mainnetParams.nMinerConfirmationWindow * 5;
+    lastBlock = firstChain.Mine(nHeight, nTime, ALGO_SCRYPT).Tip();
+    BOOST_CHECK_EQUAL(ComputeBlockVersion(lastBlock, mainnetParams, ALGO_SCRYPT) & (1<<bit), 0);
 
     // On a new chain:
     // verify that the bit will be set after lock-in, and then stop being set
@@ -330,25 +330,25 @@ BOOST_AUTO_TEST_CASE(versionbits_computeblockversion)
 
     // Mine one period worth of blocks, and check that the bit will be on for the
     // next period.
-    lastBlock = secondChain.Mine(2016, nTime, VERSIONBITS_LAST_OLD_BLOCK_VERSION).Tip();
-    BOOST_CHECK((ComputeBlockVersion(lastBlock, mainnetParams, 2) & (1<<bit)) != 0);
+    lastBlock = secondChain.Mine(mainnetParams.nMinerConfirmationWindow, nTime, ALGO_SCRYPT).Tip();
+    BOOST_CHECK((ComputeBlockVersion(lastBlock, mainnetParams, ALGO_SCRYPT) & (1<<bit)) != 0);
 
     // Mine another period worth of blocks, signaling the new bit.
-    lastBlock = secondChain.Mine(4032, nTime, VERSIONBITS_TOP_BITS | (1<<bit)).Tip();
+    lastBlock = secondChain.Mine(mainnetParams.nMinerConfirmationWindow * 2, nTime, VERSIONBITS_TOP_BITS | (1<<bit)).Tip();
     // After one period of setting the bit on each block, it should have locked in.
     // We keep setting the bit for one more period though, until activation.
-    BOOST_CHECK((ComputeBlockVersion(lastBlock, mainnetParams, 2) & (1<<bit)) != 0);
+    BOOST_CHECK((ComputeBlockVersion(lastBlock, mainnetParams, ALGO_SCRYPT) & (1<<bit)) != 0);
 
     // Now check that we keep mining the block until the end of this period, and
     // then stop at the beginning of the next period.
-    lastBlock = secondChain.Mine(6047, nTime, VERSIONBITS_LAST_OLD_BLOCK_VERSION).Tip();
-    BOOST_CHECK((ComputeBlockVersion(lastBlock, mainnetParams, 2) & (1<<bit)) != 0);
-    lastBlock = secondChain.Mine(6048, nTime, VERSIONBITS_LAST_OLD_BLOCK_VERSION).Tip();
-    BOOST_CHECK_EQUAL(ComputeBlockVersion(lastBlock, mainnetParams, 2) & (1<<bit), 0);
+    lastBlock = secondChain.Mine((mainnetParams.nMinerConfirmationWindow * 3) - 1, nTime, ALGO_SCRYPT).Tip();
+    BOOST_CHECK((ComputeBlockVersion(lastBlock, mainnetParams, ALGO_SCRYPT) & (1 << bit)) != 0);
+    lastBlock = secondChain.Mine(mainnetParams.nMinerConfirmationWindow * 3, nTime, ALGO_SCRYPT).Tip();
+    BOOST_CHECK_EQUAL(ComputeBlockVersion(lastBlock, mainnetParams, ALGO_SCRYPT) & (1<<bit), 0);
 
     // Finally, verify that after a soft fork has activated, CBV no longer uses
-    // VERSIONBITS_LAST_OLD_BLOCK_VERSION.
-    //BOOST_CHECK_EQUAL(ComputeBlockVersion(lastBlock, mainnetParams) & VERSIONBITS_TOP_MASK, VERSIONBITS_TOP_BITS);
+    // ALGO_SCRYPT.
+    //BOOST_CHECK_EQUAL(ComputeBlockVersion(lastBlock, mainnetParams, ALGO_SCRYPT) & VERSIONBITS_TOP_MASK, VERSIONBITS_TOP_BITS);
 }
 
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -46,6 +46,7 @@
 
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/thread.hpp>
+#include <boost/bind.hpp>
 
 #if defined(NDEBUG)
 # error "DigiByte cannot be compiled without assertions."

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -17,6 +17,7 @@
 #include <atomic>
 #include <future>
 
+#include <boost/bind.hpp>
 #include <boost/signals2/signal.hpp>
 
 struct MainSignalsInstance {


### PR DESCRIPTION
# DigiByte specific versionbits_test

### What is the intention of this PR?
This PR fixes the `versionbits_test` with DigiByte's specific Block Parameters.

### Description of the changes
https://github.com/DigiByte-Core/digibyte/pull/26/commits/05d6ccb11a4314a5fb074e95a364c84b96b75eb3 updated the `versionbits_test` unit test in order to fix the unit test issues by iterating through the correct block ranges and using the correct miner confirmation windows.

### How to verify?
1) Change to the directory src/test
2) Compile the test suite
3) Run it using
```bash
./test_digibyte --run_test=versionbits_test
```

### Expected outcome
```
$ ./test_digibyte --run_test=versionbits_tests 
Running 2 test cases...

*** No errors detected
```