### PR TITLE
test: correct rpc_tests

### DIFF
--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -109,7 +109,7 @@ BOOST_AUTO_TEST_CASE(rpc_rawsign)
       "\"vout\":1,\"scriptPubKey\":\"a914b10c9df5f7edf436c697f02f1efdba4cf399615187\","
       "\"redeemScript\":\"512103debedc17b3df2badbcdd86d5feb4562b86fe182e5998abd8bcd4f122c6155b1b21027e940bb73ab8732bfdf7f9216ecefca5b94d6df834e77e108f68e66f126044c052ae\"}]";
     r = CallRPC(std::string("createrawtransaction ")+prevout+" "+
-      "{\"3HqAe9LtNBjnsfM4CyYaWTnvCaUYT7v4oZ\":11}");
+      "{\"DS1P3gwq6MFtatWprr2e2J32xGPd89n75C\":11}");
     std::string notsigned = r.get_str();
     std::string privkey1 = "\"KzsXybp9jX64P5ekX1KUxRQ79Jht9uzW7LorgwE65i5rWACL6LQe\"";
     std::string privkey2 = "\"Kyhdf5LuKTRx4ge69ybABsiUAWjVRK4XGxAKk2FQLp2HjGMy87Z4\"";

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -46,6 +46,7 @@
 
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/thread.hpp>
+#include <boost/bind.hpp>
 
 #if defined(NDEBUG)
 # error "DigiByte cannot be compiled without assertions."

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -17,6 +17,7 @@
 #include <atomic>
 #include <future>
 
+#include <boost/bind.hpp>
 #include <boost/signals2/signal.hpp>
 
 struct MainSignalsInstance {


### PR DESCRIPTION
# DigiByte specific rpc_tests

### What is the intention of this PR?
This PR fixes the `rpc_tests` with DigiByte's specific Network Parameters.

### Description of the changes
The commit https://github.com/SmartArray/digibyte/commit/6fb477478e873143926fb14dcf2dd8a423d5a039 updated the `rpc_tests` unit test in order to fix the unit test issues.

### How to verify?
1) Change to the directory src/test
2) Compile the test suite
3) Run it using
```bash
./test_digibyte --run_test=rpc_tests
```

### Expected outcome
```
$ ./test_digibyte --run_test=rpc_tests
Running 10 test cases...

*** No errors detected
```