### PR TITLE
test follow-up: fixed locking issue in tx_validationcache_tests

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -498,6 +498,8 @@ public:
         consensus.nLocalTargetAdjustment = 4; //target adjustment per algo
         consensus.nLocalDifficultyAdjustment = 4; //difficulty adjustment per algo
 
+        consensus.BIP65Height = 1351;
+        consensus.BIP66Height = 1251;
 
         // DigiByte Hard Fork Block Heights
         consensus.multiAlgoDiffChangeTarget = 145; // Block 145,000 MultiAlgo Hard Fork

--- a/src/test/txvalidationcache_tests.cpp
+++ b/src/test/txvalidationcache_tests.cpp
@@ -220,10 +220,10 @@ BOOST_FIXTURE_TEST_CASE(checkinputs_test, TestChain100Setup)
     CBlock block;
 
     block = CreateAndProcessBlock({spend_tx}, p2pk_scriptPubKey);
+    LOCK(cs_main);
     BOOST_CHECK(chainActive.Tip()->GetBlockHash() == block.GetHash());
     BOOST_CHECK(pcoinsTip->GetBestBlock() == block.GetHash());
 
-    LOCK(cs_main);
 
     // Test P2SH: construct a transaction that is valid without P2SH, and
     // then test validity with P2SH.


### PR DESCRIPTION
# Fixed locking issue in tx_validationcache_tests

`tx_validationcache_tests` had a small locking issue, which I needed to resolve so that we achieve an deterministic integration coverage.

The commit https://github.com/DigiByte-Core/digibyte/commit/a5c94bb4c3200d2805582046e42ad945b84e3225 fixes the wrong-positioned thread locking mechanism.

Another commit has been added that solves the actual origin of the non-determinism: https://github.com/DigiByte-Core/digibyte/commit/8df59ff73f6fc1ddd9d87fafc08acbe2f6e90e65. This commit adds some regtest chainparams, especially for BIP66.

## How to validate?

Build and run the `digibyte_test` as follows:
```bash
for i in `seq 0 10`; do ./test_digibyte -t tx_validationcache_tests; done
```

## Expected results
```bash
Running 2 test cases...

*** No errors detected
Running 2 test cases...

*** No errors detected
Running 2 test cases...

*** No errors detected
Running 2 test cases...

*** No errors detected
Running 2 test cases...

*** No errors detected
Running 2 test cases...

*** No errors detected
Running 2 test cases...

*** No errors detected
Running 2 test cases...

*** No errors detected
Running 2 test cases...

*** No errors detected
Running 2 test cases...

*** No errors detected
```
