### PR TITLE
Disable TESTNET Subsidy Tests

### DIFF
--- a/src/test/main_tests.cpp
+++ b/src/test/main_tests.cpp
@@ -46,6 +46,10 @@
     #define SECONDS_PER_MONTH (60 * 60 * 24 * 365 / 12)
 #endif    
 
+#ifndef ENABLE_TESTNET_SUBSIDY_TESTS
+    #define ENABLE_TESTNET_SUBSIDY_TESTS 0
+#endif
+
 BOOST_FIXTURE_TEST_SUITE(main_tests, TestingSetup)
 
 static void TestBlockSubsidy(const Consensus::Params& consensusParams, int nMaxBlocks, CAmount* nSumOut)
@@ -192,9 +196,8 @@ BOOST_AUTO_TEST_CASE(block_subsidy_test)
 #if OUTPUT_SUPPLY_SAMPLES_ENABLED
     // Output the accumulated supply until END_OF_SUPPLY_CURVE
     std::cout << "(mainnet): MAXIMUM SUPPLY: " << sum << " dgbSATS (" << (sum / COIN) << " DGB)";
-#else
-    // Only perform test on TESTNET too, if we are not
-    // outputting the sampled supply data.
+#elif ENABLE_TESTNET_SUBSIDY_TESTS != 0
+    // Only perform test on TESTNET too if requested so.
     TestBlockSubsidy(testChainParams->GetConsensus(), END_OF_SUPPLY_CURVE, NULL); // Testnet
 #endif
 }


### PR DESCRIPTION
# Disable TESTNET Subsidy Tests

This PR aims to disable the Testnet Subsidy Curve Validation to save another 3-4 minutes when running through CI.

The PR consists of a single commit https://github.com/DigiByte-Core/digibyte/pull/38/commits/ce1a1ae9ced33779f3753d9129ffd9b91340b8fd that introduces a build-time macro constant
`ENABLE_TESTNET_SUBSIDY_TESTS` which defaults to zero.

### How to verify?
1) Compile digibyte using `make -j4`
2) Change to the directory src/test
3) Run it using
```bash
./test_digibyte -t main_tests
```

### Expected outcome
```                    
Running 2 test cases...

*** No errors detected
```