### PR TITLE
WIP: Initial fix for infinite supply, issue #20, to coincide with supply-curve smoothing

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -81,7 +81,7 @@ public:
         consensus.BIP34Hash = uint256S("0xadd8ca420f557f62377ec2be6e6f47b96cf2e68160d58aeb7b73433de834cca0");
         consensus.BIP65Height = 4394880; // 
         consensus.BIP66Height = 4394880; // 
-	consensus.workFinalBlockSubsidy = 40265288; // Final block before we reach 21bn DGB
+        consensus.workFinalBlockSubsidy = 40266213; // Final block before we reach 21bn DGB @ 2034-05-10 (potential actual supply)
 
         consensus.powLimit = ArithToUint256(~arith_uint256(0) >> 20);
         consensus.initialTarget[ALGO_ODO] = ArithToUint256(~arith_uint256(0) >> 40); // 256 difficulty

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -81,6 +81,7 @@ public:
         consensus.BIP34Hash = uint256S("0xadd8ca420f557f62377ec2be6e6f47b96cf2e68160d58aeb7b73433de834cca0");
         consensus.BIP65Height = 4394880; // 
         consensus.BIP66Height = 4394880; // 
+	consensus.workFinalBlockSubsidy = 40265288; // Final block before we reach 21bn DGB
 
         consensus.powLimit = ArithToUint256(~arith_uint256(0) >> 20);
         consensus.initialTarget[ALGO_ODO] = ArithToUint256(~arith_uint256(0) >> 40); // 256 difficulty

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -125,6 +125,7 @@ struct Params {
 
     uint256 nMinimumChainWork;
     uint256 defaultAssumeValid;
+    uint32_t workFinalBlockSubsidy;
     bool EnableRBF() const { return fRbfEnabled; }
 };
 } // namespace Consensus

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -125,7 +125,7 @@ struct Params {
 
     uint256 nMinimumChainWork;
     uint256 defaultAssumeValid;
-    uint32_t workFinalBlockSubsidy;
+    int64_t workFinalBlockSubsidy;
     bool EnableRBF() const { return fRbfEnabled; }
 };
 } // namespace Consensus

--- a/src/test/main_tests.cpp
+++ b/src/test/main_tests.cpp
@@ -162,10 +162,6 @@ static void TestBlockSubsidy(const Consensus::Params& consensusParams, int nMaxB
                 }
             }
 
-            if (nExpectedSubsidy < COIN) { // ToDo: Alter consensus
-                nExpectedSubsidy = COIN;
-            }
-
             BOOST_CHECK_EQUAL(nSubsidy, nExpectedSubsidy);
 
             nSum += nSubsidy;

--- a/src/test/main_tests.cpp
+++ b/src/test/main_tests.cpp
@@ -52,13 +52,19 @@
 
 BOOST_FIXTURE_TEST_SUITE(main_tests, TestingSetup)
 
+// checks for:
+// 1. block subsidy in the past hasn't been altered (The past is fixed but the future is malleable)
+// 2. block subsidy never increases, so subsidy(n) <= subsidy(n+1), n is a block height
+// 3. block subsidy eventually hits 0
 static void TestBlockSubsidy(const Consensus::Params& consensusParams, int nMaxBlocks, CAmount* nSumOut)
 {
+    const CAmount BlockHeightVerbatimCheck = 14394800; // ~(2022-01-21)
     CAmount nSum = 0;
     CAmount nInitialSubsidy = 72000 * COIN;
 
     CAmount nPreviousSubsidy = nInitialSubsidy * 2; // for height == 0
     BOOST_CHECK_EQUAL(nPreviousSubsidy, nInitialSubsidy * 2);
+    BOOST_REQUIRE(BlockHeightVerbatimCheck <= nMaxBlocks);  // sanity check
 
     /* Before first hard fork */
 
@@ -67,7 +73,7 @@ static void TestBlockSubsidy(const Consensus::Params& consensusParams, int nMaxB
     {
         int nHeight = nBlocks;
         CAmount nSubsidy = GetBlockSubsidy(nHeight, consensusParams);
-        BOOST_CHECK_EQUAL(nSubsidy, nInitialSubsidy);
+        BOOST_REQUIRE_EQUAL(nSubsidy, nInitialSubsidy);
 
         nSum += nSubsidy;
         DEBUG(nBlocks, nSubsidy);
@@ -78,7 +84,7 @@ static void TestBlockSubsidy(const Consensus::Params& consensusParams, int nMaxB
     {
         int nHeight = nBlocks;
         CAmount nSubsidy = GetBlockSubsidy(nHeight, consensusParams);
-        BOOST_CHECK_EQUAL(nSubsidy, 16000 * COIN);
+        BOOST_REQUIRE_EQUAL(nSubsidy, 16000 * COIN);
 
         nSum += nSubsidy;
         DEBUG(nBlocks, nSubsidy);
@@ -89,7 +95,7 @@ static void TestBlockSubsidy(const Consensus::Params& consensusParams, int nMaxB
     {
         int nHeight = nBlocks;
         CAmount nSubsidy = GetBlockSubsidy(nHeight, consensusParams);
-        BOOST_CHECK_EQUAL(nSubsidy, 8000 * COIN);  
+        BOOST_REQUIRE_EQUAL(nSubsidy, 8000 * COIN);
 
         nSum += nSubsidy;
         DEBUG(nBlocks, nSubsidy);
@@ -108,7 +114,7 @@ static void TestBlockSubsidy(const Consensus::Params& consensusParams, int nMaxB
             nExpectedSubsidy -= nExpectedSubsidy / 200; // dec by 0.5%
         }
 
-        BOOST_CHECK_EQUAL(nSubsidy, nExpectedSubsidy);
+        BOOST_REQUIRE_EQUAL(nSubsidy, nExpectedSubsidy);
 
         nSum += nSubsidy;
         DEBUG(nBlocks, nSubsidy);
@@ -127,7 +133,7 @@ static void TestBlockSubsidy(const Consensus::Params& consensusParams, int nMaxB
             nExpectedSubsidy -= nExpectedSubsidy / 100; // dec by 1% per month
         }
 
-        BOOST_CHECK_EQUAL(nSubsidy, nExpectedSubsidy);
+        BOOST_REQUIRE_EQUAL(nSubsidy, nExpectedSubsidy);
 
         nSum += nSubsidy;
         DEBUG(nBlocks, nSubsidy);
@@ -136,12 +142,11 @@ static void TestBlockSubsidy(const Consensus::Params& consensusParams, int nMaxB
     {
         // Updated dynamic mining rewards from block height 1,430,000 to max block height.
         // Intended blockheight: 41.6 million
-        // Actual blockheight: 110.5 million
         CAmount nExpectedSubsidyStart = 2157 * COIN / 2;
         CAmount nExpectedSubsidy = nExpectedSubsidyStart;
         int nMonthsConsidered = 0;
 
-        for (int nBlocks = consensusParams.workComputationChangeTarget; nBlocks < nMaxBlocks; ++nBlocks) {
+        for (int nBlocks = consensusParams.workComputationChangeTarget; nBlocks < BlockHeightVerbatimCheck; ++nBlocks) {
             int nHeight = nBlocks;
             CAmount nSubsidy = GetBlockSubsidy(nHeight, consensusParams);
 
@@ -162,17 +167,30 @@ static void TestBlockSubsidy(const Consensus::Params& consensusParams, int nMaxB
                 }
             }
 
-            BOOST_CHECK_EQUAL(nSubsidy, nExpectedSubsidy);
+            BOOST_REQUIRE_EQUAL(nSubsidy, nExpectedSubsidy);
 
             nSum += nSubsidy;
+            nPreviousSubsidy = nSubsidy;
+            DEBUG(nBlocks, nSubsidy);
+        }
+    }
+
+    {
+        // Future block checks which don't need to exactly match anything
+        for (int nBlocks = BlockHeightVerbatimCheck; nBlocks < nMaxBlocks; ++nBlocks) {
+            int nHeight = nBlocks;
+            CAmount nSubsidy = GetBlockSubsidy(nHeight, consensusParams);
+
+            BOOST_REQUIRE_LE(nSubsidy, nPreviousSubsidy);
+
+            nSum += nSubsidy;
+            nPreviousSubsidy = nSubsidy;
             DEBUG(nBlocks, nSubsidy);
         }
     }
 
     CAmount nSubsidy = GetBlockSubsidy(nMaxBlocks, consensusParams);
-    CAmount nExpectedSubsidy = 1 * COIN;
-
-    BOOST_CHECK_EQUAL(nSubsidy, nExpectedSubsidy);
+    BOOST_REQUIRE_EQUAL(nSubsidy, 0);
 
     if (nSumOut != NULL) {
         *nSumOut = nSum;
@@ -186,7 +204,7 @@ BOOST_AUTO_TEST_CASE(block_subsidy_test)
     const auto testChainParams = CreateChainParams(CBaseChainParams::TESTNET);
     TestBlockSubsidy(chainParams->GetConsensus(), END_OF_SUPPLY_CURVE, &sum); // Mainnet
 
-    CAmount nExpectedTotalSupply = 2239167398214795680ULL;
+    CAmount nExpectedTotalSupply = 2100024577003013036ULL;  // this is the maximum supply, not the actual supply
     BOOST_CHECK_EQUAL(sum, nExpectedTotalSupply);
 
 #if OUTPUT_SUPPLY_SAMPLES_ENABLED

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1219,7 +1219,7 @@ CAmount GetBlockSubsidy(int nHeight, const Consensus::Params& consensusParams)
             nSubsidy -= (nSubsidy / 100);
         }
     }
-    else // < ∞
+    else if (nHeight < consensusParams.workFinalBlockSubsidy) // < 40265288
     {
         // (Period VI)
         // Hard Fork Point: 1.43M
@@ -1236,13 +1236,13 @@ CAmount GetBlockSubsidy(int nHeight, const Consensus::Params& consensusParams)
             nSubsidy *= 98884;
             nSubsidy /= 100000;
         }
-    }
-
-    // Make sure the reward is at least 1 DGB
-    // ToDo: Remove this statement in a future release, along
-    // with a fixed supply curve.
-    if (nSubsidy < COIN) {
-        nSubsidy = COIN;
+    else
+    {
+	// If we've exceeded workFinalBlockSubsidy, we're in 2035-ish
+	// We should have also reached the end of our emissions
+	// This relies on the emissions curve also being fixed elsewhere
+	// However this stops the infinite supply
+	nSubsidy = 0;
     }
 
     return nSubsidy;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1236,6 +1236,7 @@ CAmount GetBlockSubsidy(int nHeight, const Consensus::Params& consensusParams)
             nSubsidy *= 98884;
             nSubsidy /= 100000;
         }
+    }
     else
     {
 	// If we've exceeded workFinalBlockSubsidy, we're in 2035-ish


### PR DESCRIPTION
This removes the infinite supply of 1 DGB, setting a cap based on blockheight.
As this code isn't something that's going to be used before ~2035 (Well actually several years past 2035 due to the supply curve also needing to be fixed) we can change that without immediately affecting the running-consensus given we're going to upgrade everybody well and truly before 2035 with the next HF upgrade.

consensus.workFinalBlockSubsidy is set to a block height of 40265288
40265288 - 13300898 (current height) = 26964390 blocks remaining. Divide by 5760/daily gives us 4681.31770833 days which is currently 12.82 years. (middle of 2034) This number needs to be further discussed and will almost definitely be adjusted though at the same time as we fix the supply curve, however it was chosen based on previous numbers done with Matthew.

If we're above that block height, nSubsidy = 0, capping the supply in a similar way to what BTC does with their nSubsidy based on halving in their chainparams.cpp with:
```
CAmount GetBlockSubsidy(int nHeight, const Consensus::Params& consensusParams)
{
    int halvings = nHeight / consensusParams.nSubsidyHalvingInterval;
    // Force block reward to zero when right shift is undefined.
    if (halvings >= 64)
        return 0;
    CAmount nSubsidy = 50 * COIN;
    // Subsidy is cut in half every 210,000 blocks which will occur approximately every 4 years.
    nSubsidy >>= halvings;
    return nSubsidy;
}
```

The unit tests will still need to be corrected to match, however this is a start of a suggestion and some productive discussion around ways we can plan to resolve the issue and include it in the next major release.

As per always, not a developer so things will likely break (hence, "Allow edits by maintainers" being ticked) and I'm aware the unit tests haven't been corrected to reflect this change either, but rather just wanting to get the ball rolling here.