### PR TITLE
Refactor DandelionShuffleThread to run in connection scheduler

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1818,7 +1818,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
     CConnman* connman = node.connman.get();
     node.scheduler->scheduleEvery([connman]{
         connman->CheckDandelionShuffle();
-    }, std::chrono::milliseconds{1000});
+    }, CHECK_DANDELION_SHUFFLE_INTERVAL);
 
 #if HAVE_SYSTEM
     StartupNotify(args);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1815,6 +1815,11 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
         banman->DumpBanlist();
     }, DUMP_BANS_INTERVAL);
 
+    CConnman* connman = node.connman.get();
+    node.scheduler->scheduleEvery([connman]{
+        connman->ThreadDandelionShuffle();
+    }, std::chrono::milliseconds{1000});
+
 #if HAVE_SYSTEM
     StartupNotify(args);
 #endif

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1817,7 +1817,7 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
 
     CConnman* connman = node.connman.get();
     node.scheduler->scheduleEvery([connman]{
-        connman->ThreadDandelionShuffle();
+        connman->CheckDandelionShuffle();
     }, std::chrono::milliseconds{1000});
 
 #if HAVE_SYSTEM

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1788,7 +1788,7 @@ void CConnman::DandelionShuffle() {
     LogPrint(BCLog::DANDELION, "After Dandelion shuffle:\n%s", GetDandelionRoutingDataDebugString());
 }
 
-void CConnman::ThreadDandelionShuffle()
+void CConnman::CheckDandelionShuffle()
 {
     {
         LOCK(cs_vNodes);

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2970,9 +2970,8 @@ void CConnman::Interrupt()
 
 void CConnman::StopThreads()
 {
-    if (threadI2PAcceptIncoming.joinable()) {
+    if (threadI2PAcceptIncoming.joinable())
         threadI2PAcceptIncoming.join();
-    }
     if (threadMessageHandler.joinable())
         threadMessageHandler.join();
     if (threadOpenConnections.joinable())
@@ -2983,8 +2982,6 @@ void CConnman::StopThreads()
         threadDNSAddressSeed.join();
     if (threadSocketHandler.joinable())
         threadSocketHandler.join();
-    if (threadDandelionShuffle.joinable())
-        threadDandelionShuffle.join();
 }
 
 void CConnman::StopNodes()

--- a/src/net.h
+++ b/src/net.h
@@ -982,6 +982,7 @@ public:
     bool insertDandelionEmbargo(const uint256& hash, const std::chrono::seconds& embargo);
     bool isTxDandelionEmbargoed(const uint256& hash) const;
     bool removeDandelionEmbargo(const uint256& hash);
+    void ThreadDandelionShuffle();
 
     /** Attempts to obfuscate tx time through exponentially distributed emitting.
         Works assuming that a single interval is used.
@@ -1038,7 +1039,6 @@ private:
     void SocketHandler();
     void ThreadSocketHandler();
     void ThreadDNSAddressSeed();
-    void ThreadDandelionShuffle();
     std::string GetDandelionRoutingDataDebugString() const;
 
 

--- a/src/net.h
+++ b/src/net.h
@@ -982,7 +982,7 @@ public:
     bool insertDandelionEmbargo(const uint256& hash, const std::chrono::seconds& embargo);
     bool isTxDandelionEmbargoed(const uint256& hash) const;
     bool removeDandelionEmbargo(const uint256& hash);
-    void ThreadDandelionShuffle();
+    void CheckDandelionShuffle();
 
     /** Attempts to obfuscate tx time through exponentially distributed emitting.
         Works assuming that a single interval is used.

--- a/src/net.h
+++ b/src/net.h
@@ -87,6 +87,7 @@ static const size_t DEFAULT_MAXRECEIVEBUFFER = 5 * 1000;
 static const size_t DEFAULT_MAXSENDBUFFER    = 1 * 1000;
 
 typedef std::chrono::seconds sec;
+typedef std::chrono::milliseconds msec;
 
 /** Maximum number of outbound peers designated as Dandelion destinations */
 static const int DANDELION_MAX_DESTINATIONS = 2;
@@ -96,6 +97,8 @@ static const sec DANDELION_SHUFFLE_INTERVAL = sec(600);
 static const sec DANDELION_EMBARGO_MINIMUM = sec(10);
 /** The average additional embargo time beyond the minimum amount */
 static const sec DANDELION_EMBARGO_AVG_ADD = sec(20);
+/** The time to wait for the scheduler before rerunning Dandelion shuffle check */
+static const msec CHECK_DANDELION_SHUFFLE_INTERVAL = msec(1000);
 
 typedef int64_t NodeId;
 

--- a/src/net.h
+++ b/src/net.h
@@ -1221,7 +1221,6 @@ private:
     std::thread threadOpenAddedConnections;
     std::thread threadOpenConnections;
     std::thread threadMessageHandler;
-    std::thread threadDandelionShuffle;    
     std::thread threadI2PAcceptIncoming;
 
     /** flag for deciding to connect to an extra outbound peer,


### PR DESCRIPTION
This PR refactors the dandelionshuffle thread, to run as a scheduler function which gets called once a second.