### PR TITLE
DGB Seed Nodes Update 

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -225,15 +225,22 @@ public:
         // This is fine at runtime as we'll fall back to using them as an addrfetch if they don't support the
         // service bits we want, but we should get them updated to support all service bits wanted by any
         // release ASAP to avoid it where possible.
+
+        //DigiByte Community Seed Nodes
         vSeeds.emplace_back("seed.digibyte.org"); // Website collective
-        vSeeds.emplace_back("dnsseed.bluematt.me"); // Matt Corallo, only supports x9
-        vSeeds.emplace_back("dnsseed.digibyte.dashjr.org"); // Luke Dashjr
-        vSeeds.emplace_back("seed.digibyteservers.io"); // ChillingSilence
-        vSeeds.emplace_back("seed.digibyte.io"); // JaredTate
-        vSeeds.emplace_back("seed.digibyteblockchain.com"); // JS555
+        vSeeds.emplace_back("seed.digibyte.io"); // Jared Tate
+        vSeeds.emplace_back("seed.digihash.co"); // Jared Tate
         vSeeds.emplace_back("dnsseed.esotericizm.site"); // DigiContributor
-        vSeeds.emplace_back("seed.digibytefoundation.org"); // DigiByteFoundation
+        vSeeds.emplace_back("seed.digibytefoundation.org"); // DigiByte Foundation
+        vSeeds.emplace_back("seed.digiexplorer.info"); // DigiByte Foundation
+        vSeeds.emplace_back("seed.digiassets.net"); // DigiByte Foundation
+        vSeeds.emplace_back("digibyteblockexplorer.com"); // DigiByte Block Explorer
+        vSeeds.emplace_back("dgb1.trezor.io"); // Trezor
+        vSeeds.emplace_back("seed2.digibyte.io"); // Jared Tate
+        vSeeds.emplace_back("seed3.digibyte.io"); // Jared Tate
+        vSeeds.emplace_back("seed.digibyteblockchain.com"); // JS555
         vSeeds.emplace_back("seed.digibyte.host"); // SashaD
+        vSeeds.emplace_back("seed.digibyteservers.io"); // ChillingSilence
 
 
         base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1,30);


### PR DESCRIPTION
Signed-off-by: Jared Tate <13957390+JaredTate@users.noreply.github.com>

After looking through the hardcoded seed nodes for DigiByte-Core as well as [digibytewallet-core](https://github.com/DigiByte-Core/digibytewallet-core/blob/master/BRChainParams.h#L48) for the mobile wallets both codebases need to be updated with more seeds to help fix connection issues now being experienced, especially the light wallets. 

Running a DGB core seed node is simple. You just need to have a URL (example: seed.digibyte.io) and a DigiByte Core full node of the latest version that's running 24/7 at that address. It's also helpful to add "maxconnections=800" or any higher number to allow more than 8 peers at a time in the digibyte.conf file.

If you are interested in running a full-time seed node for the next few years to help the network out please mention it in a comment below with the URL. Let me know if you see any issues with seeds listed below.

```    
        //DigiByte Community Seed Nodes
        vSeeds.emplace_back("seed.digibyte.org"); // Website collective
        vSeeds.emplace_back("seed.digibyte.io"); // Jared Tate
        vSeeds.emplace_back("seed.digihash.co"); // Jared Tate
        vSeeds.emplace_back("dnsseed.esotericizm.site"); // DigiContributor
        vSeeds.emplace_back("seed.digibytefoundation.org"); // DigiByte Foundation
        vSeeds.emplace_back("seed.digiexplorer.info"); // DigiByte Foundation
        vSeeds.emplace_back("seed.digiassets.net"); // DigiByte Foundation
        vSeeds.emplace_back("digibyteblockexplorer.com"); // DigiByte Block Explorer
        vSeeds.emplace_back("dgb1.trezor.io"); // Trezor
        vSeeds.emplace_back("seed2.digibyte.io"); // Jared Tate
        vSeeds.emplace_back("seed3.digibyte.io"); // Jared Tate
        vSeeds.emplace_back("seed.digibyteblockchain.com"); // JS555
        vSeeds.emplace_back("seed.digibyte.host"); // SashaD
        vSeeds.emplace_back("seed.digibyteservers.io"); // ChillingSilence