### PR TITLE
Prevent algo bits from triggering 'unknown new rules' message

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -104,14 +104,6 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nTimeout = 1230767999; // December 31, 2008
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].min_activation_height = 0; // No activation delay
 
-        // Deployment of Odo proof-of-work hardfork
-        consensus.vDeployments[Consensus::DEPLOYMENT_ODO].bit = 6;
-        consensus.vDeployments[Consensus::DEPLOYMENT_ODO].nStartTime = 1556668800; // 1 May, 2019
-        consensus.vDeployments[Consensus::DEPLOYMENT_ODO].nTimeout = 1588291200;    // 1 May, 2020
-
-        // Block 9112320 hash 906b712a7b1f54f10b0faf86111e832ddb7b8ce86ac71a4edd2c61e5ccfe9428
-        consensus.vDeployments[Consensus::DEPLOYMENT_ODO].min_activation_height = 9112320; 
-
         // Deployment of Taproot (BIPs 340-342)
         consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].bit = 2;
         consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].nStartTime = 1630454400; // Sept 1st, 2021

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2366,6 +2366,9 @@ void CChainState::UpdateTip(const CBlockIndex* pindexNew)
         for (int bit = 0; bit < VERSIONBITS_NUM_BITS; bit++) {
             WarningBitsConditionChecker checker(bit);
             ThresholdState state = checker.GetStateFor(pindex, m_params.GetConsensus(), warningcache[bit]);
+            // dont trigger 'unknown new rules' warning if the bit falls within
+            // the block algo version range (enum in primitives/block.h)
+            if (bit <= BLOCK_VERSION_ALGO) continue;
             if (state == ThresholdState::ACTIVE || state == ThresholdState::LOCKED_IN) {
                 const bilingual_str warning = strprintf(_("Unknown new rules activated (versionbit %i)"), bit);
                 if (state == ThresholdState::ACTIVE) {


### PR DESCRIPTION
There have been a few incorrect attempts at removing the 'unknown new rules' message.
This PR prevents any warning from being triggered if the target bit is less than the max block algo version (const BLOCK_VERSION_ALGO).
