### PR TITLE
Remove legacy odocrypt fork code

### DIFF
--- a/src/version.h
+++ b/src/version.h
@@ -16,7 +16,7 @@ static const int PROTOCOL_VERSION = 70018;
 static const int INIT_PROTO_VERSION = 209;
 
 //! disconnect from peers older than this proto version
-static const int MIN_PEER_PROTO_VERSION = 31800;
+static const int MIN_PEER_PROTO_VERSION = 70017;
 
 //! BIP 0031, pong message, is enabled for all versions AFTER this one
 static const int BIP0031_VERSION = 60000;
@@ -35,9 +35,6 @@ static const int SHORT_IDS_BLOCKS_VERSION = 70014;
 
 //! not banning for invalid compact blocks starts with this version
 static const int INVALID_CB_NO_BAN_VERSION = 70015;
-
-//! first odo version
-static const int ODO_FORK_VERSION = 70017;
 
 //! "wtxidrelay" command for wtxid-based relay starts with this version
 static const int WTXID_RELAY_VERSION = 70019;


### PR DESCRIPTION
All digibyte clients are now at a sufficient PROTOCOL_VERSION, where they won't attempt to communicate with older clients.