### PR TITLE
accelerate LoadBlockIndex when last algo block is ancient or non-existent

### DIFF
--- a/src/chain.cpp
+++ b/src/chain.cpp
@@ -162,8 +162,13 @@ arith_uint256 GetBlockProofBase(const CBlockIndex& block)
     return (~bnTarget / (bnTarget + 1)) + 1;
 }
 
+arith_uint256 GetBlockProof(const CBlockIndex& block) {
+    blockAgloCache_t dummyBlockCache;
+    return GetBlockProof(block, dummyBlockCache);
+}
+
 // DGB 6.14.1 GetBlock Proof
-arith_uint256 GetBlockProof(const CBlockIndex& block)
+arith_uint256 GetBlockProof(const CBlockIndex& block, blockAgloCache_t& blockCache)
 {
     CBlockHeader header = block.GetBlockHeader();
     int nHeight = block.nHeight;
@@ -173,6 +178,7 @@ arith_uint256 GetBlockProof(const CBlockIndex& block)
     {
         arith_uint256 bnBlockWork = GetBlockProofBase(block);
         uint32_t nAlgoWork = GetAlgoWorkFactor(nHeight, header.GetAlgo());
+        // LogPrintf("%d < %d, bnBlockWork = %s, nAlgoWork = %d \n", nHeight, params.workComputationChangeTarget, bnBlockWork.ToString(), nAlgoWork);
         return bnBlockWork * nAlgoWork;
     }
     else
@@ -184,7 +190,7 @@ arith_uint256 GetBlockProof(const CBlockIndex& block)
         {
             if (!IsAlgoActive(block.pprev, params, i))
                 continue;
-            unsigned int nBits = GetNextWorkRequired(block.pprev, &header, params, i);
+            unsigned int nBits = GetNextWorkRequired(block.pprev, &header, params, i, blockCache);
             arith_uint256 bnTarget;
             bool fNegative;
             bool fOverflow;
@@ -200,7 +206,7 @@ arith_uint256 GetBlockProof(const CBlockIndex& block)
         arith_uint256 bnRes = (~bnAvgTarget / (bnAvgTarget + 1)) + 1;
         // Scale to roughly match the old work calculation
         bnRes <<= 7;
-
+        // LogPrintf("%d >= %d, bnRes = %s \n", nHeight, params.workComputationChangeTarget, bnRes.ToString());
         return bnRes;
     }
 }

--- a/src/chain.h
+++ b/src/chain.h
@@ -258,8 +258,22 @@ public:
 
     int GetAlgo() const
     {
-        CBlockHeader block = GetBlockHeader();
-        return block.GetAlgo();
+        switch (nVersion & BLOCK_VERSION_ALGO)
+        {
+            case BLOCK_VERSION_SCRYPT:
+                return ALGO_SCRYPT;
+            case BLOCK_VERSION_SHA256D:
+                return ALGO_SHA256D;
+            case BLOCK_VERSION_GROESTL:
+                return ALGO_GROESTL;
+            case BLOCK_VERSION_SKEIN:
+                return ALGO_SKEIN;
+            case BLOCK_VERSION_QUBIT:
+                return ALGO_QUBIT;
+            case BLOCK_VERSION_ODO:
+                return ALGO_ODO;
+        }
+        return ALGO_UNKNOWN;
     }
     
     /**
@@ -338,6 +352,7 @@ public:
 };
 
 arith_uint256 GetBlockProof(const CBlockIndex& block);
+arith_uint256 GetBlockProof(const CBlockIndex& block, blockAgloCache_t& blockCache);
 
 /** Return the time it would take to redo the work difference between from and to, assuming the current hashrate corresponds to the difficulty at tip, in seconds. */
 int64_t GetBlockProofEquivalentTime(const CBlockIndex& to, const CBlockIndex& from, const CBlockIndex& tip, const Consensus::Params&);

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -4,6 +4,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <cstdint>
 #include <pow.h>
 #include <logging.h>
 #include <arith_uint256.h>
@@ -11,6 +12,7 @@
 #include <primitives/block.h>
 #include <uint256.h>
 #include <chainparams.h>
+#include <unordered_map>
 
 inline unsigned int PowLimit(const Consensus::Params& params)
 {
@@ -190,7 +192,7 @@ unsigned int GetNextWorkRequiredV3(const CBlockIndex* pindexLast, const Consensu
     return bnNew.GetCompact();
 }
 
-unsigned int GetNextWorkRequiredV4(const CBlockIndex* pindexLast, const Consensus::Params& params, int algo)
+unsigned int GetNextWorkRequiredV4(const CBlockIndex* pindexLast, const Consensus::Params& params, int algo, blockAgloCache_t& bestAlgoBlocks)
 {
     // find first block in averaging interval
     // Go back by what we want to be nAveragingInterval blocks per algo
@@ -200,11 +202,18 @@ unsigned int GetNextWorkRequiredV4(const CBlockIndex* pindexLast, const Consensu
         pindexFirst = pindexFirst->pprev;
     }
 
-    const CBlockIndex* pindexPrevAlgo = GetLastBlockIndexForAlgo(pindexLast, params, algo);
-    if (pindexPrevAlgo == nullptr || pindexFirst == nullptr)
-    {
+	if (pindexFirst == nullptr)
+		return InitialDifficulty(params, algo);
+
+	const CBlockIndex* pindexPrevAlgo = nullptr;
+	auto bbA = bestAlgoBlocks.find(algo);
+	if (bbA == bestAlgoBlocks.end())
+		pindexPrevAlgo = GetLastBlockIndexForAlgo(pindexLast, params, algo);
+	else if (bbA->second->nHeight < pindexLast->nHeight)
+		pindexPrevAlgo = bbA->second;
+		
+	if (pindexPrevAlgo == nullptr) // never happened
         return InitialDifficulty(params, algo);
-    }
 
     // Limit adjustment step
     // Use medians to prevent time-warp attacks
@@ -247,10 +256,17 @@ unsigned int GetNextWorkRequiredV4(const CBlockIndex* pindexLast, const Consensu
         bnNew = UintToArith256(params.powLimit);
     }
 
+	bestAlgoBlocks[algo] = pindexLast; // for next time
+
     return bnNew.GetCompact();
 }
 
-unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader *pblock, const Consensus::Params& params, int algo)
+unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader *pblock, const Consensus::Params& params, int algo) {
+	blockAgloCache_t dummyBlockCache;
+	return GetNextWorkRequired(pindexLast, pblock, params, algo, dummyBlockCache);
+}
+
+unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader *pblock, const Consensus::Params& params, int algo, blockAgloCache_t &bestAlgoBlocks)
 {
     // Genesis block
     if (pindexLast == nullptr)
@@ -278,7 +294,7 @@ unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHead
     } else if(pindexLast->nHeight < params.workComputationChangeTarget)
         return GetNextWorkRequiredV3(pindexLast, params, algo);
     else
-        return GetNextWorkRequiredV4(pindexLast, params, algo);
+		return GetNextWorkRequiredV4(pindexLast, params, algo, bestAlgoBlocks);
 }
 
 unsigned int CalculateNextWorkRequired(const CBlockIndex* pindexLast, int64_t nFirstBlockTime, const Consensus::Params& params)

--- a/src/pow.h
+++ b/src/pow.h
@@ -9,18 +9,22 @@
 
 #include <consensus/params.h>
 
+#include <unordered_map>
 #include <stdint.h>
 
 class CBlockHeader;
 class CBlockIndex;
 class uint256;
 
+typedef std::unordered_map<int, const CBlockIndex*> blockAgloCache_t;
+
 unsigned int InitialDifficulty(const Consensus::Params& params, int algo);
 unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader *pblock, const Consensus::Params&, int algo);
+unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader *pblock, const Consensus::Params&, int algo, blockAgloCache_t& blockCache);
 unsigned int GetNextWorkRequiredv1(const CBlockIndex* pindexLast, const CBlockHeader *pblock, const Consensus::Params&, int algo);
 unsigned int GetNextWorkRequiredv2(const CBlockIndex* pindexLast, const CBlockHeader *pblock, const Consensus::Params&, int algo);
 unsigned int GetNextWorkRequiredv3(const CBlockIndex* pindexLast, const CBlockHeader *pblock, const Consensus::Params&, int algo);
-unsigned int GetNextWorkRequiredv4(const CBlockIndex* pindexLast, const CBlockHeader *pblock, const Consensus::Params&, int algo);
+unsigned int GetNextWorkRequiredv4(const CBlockIndex* pindexLast, const CBlockHeader *pblock, const Consensus::Params&, int algo, blockAgloCache_t& blockCache);
 unsigned int CalculateNextWorkRequired(const CBlockIndex* pindexLast, int64_t nFirstBlockTime, const Consensus::Params&);
 
 /** Check whether a block hash satisfies the proof-of-work requirement specified by nBits */

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -3,6 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <boost/bind.hpp>
+
 #include <qt/clientmodel.h>
 
 #include <qt/bantablemodel.h>

--- a/src/qt/digibytegui.cpp
+++ b/src/qt/digibytegui.cpp
@@ -3,6 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <boost/bind.hpp>
+
 #include <qt/digibytegui.h>
 
 #include <qt/digibyteunits.h>

--- a/src/qt/splashscreen.cpp
+++ b/src/qt/splashscreen.cpp
@@ -7,6 +7,8 @@
 #include <config/digibyte-config.h>
 #endif
 
+#include <boost/bind.hpp>
+
 #include <qt/splashscreen.h>
 
 #include <clientversion.h>

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -3,6 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <boost/bind.hpp>
+
 #include <qt/transactiontablemodel.h>
 
 #include <qt/addresstablemodel.h>

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -7,6 +7,8 @@
 #include <config/digibyte-config.h>
 #endif
 
+#include <boost/bind.hpp>
+
 #include <qt/walletmodel.h>
 
 #include <qt/addresstablemodel.h>

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3878,11 +3878,12 @@ bool BlockManager::LoadBlockIndex(
         vSortedByHeight.push_back(std::make_pair(pindex->nHeight, pindex));
     }
     sort(vSortedByHeight.begin(), vSortedByHeight.end());
+    blockAgloCache_t blockCache(NUM_ALGOS_IMPL);
     for (const std::pair<int, CBlockIndex*>& item : vSortedByHeight)
     {
         if (ShutdownRequested()) return false;
         CBlockIndex* pindex = item.second;
-        pindex->nChainWork = (pindex->pprev ? pindex->pprev->nChainWork : 0) + GetBlockProof(*pindex);
+        pindex->nChainWork = (pindex->pprev ? pindex->pprev->nChainWork : 0) + GetBlockProof(*pindex, blockCache);
         pindex->nTimeMax = (pindex->pprev ? std::max(pindex->pprev->nTimeMax, pindex->nTime) : pindex->nTime);
         // We can link the chain of blocks for which we've received transactions at some point.
         // Pruned nodes may have deleted the block.


### PR DESCRIPTION
**DO NOT USE ON mainnet.**  Backup your datadir before testing.

Part of `GetNextRequiredWork` involves loading the previous block that was mined with a given PoW hashing algorithm.  See `GetLastBlockIndexForAlgo`.  This can involve tracing back thousands of blocks (or the entire chain if there has never been a block with a given algo).  In practice (mainnet), this is generally not a problem because there is likely to be hash rate and new blocks fairly regularly for each algorithm.  However, for testnet, algos like odo can just never get used, causing the "Loading block index..." stage to take close to a day as it traverses the entire length of the chain for each block that it adds to the index as it is being loaded.

A workaround to this issue is to provide an optional cache of latest/previous blocks for each hash algorithm, which is used only by `CChainState::LoadBlockIndex` when calling `GetBlockProof`.

Probably the best way this could be handled is to have upgraded the block index for pow v4 to include this "last block for this algo" value.

This PR is for 8.22 development.  The equivalent fixes for 7.17.3 are on https://github.com/chappjc/digibyte/tree/patches7