### PR TITLE
Remove non-functioning seeders and full nodes

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -142,23 +142,21 @@ public:
         // service bits we want, but we should get them updated to support all service bits wanted by any
         // release ASAP to avoid it where possible.
 
-        //DigiByte Community Seed Nodes
-        vSeeds.emplace_back("seed.digibyte.org"); // Website collective
-        vSeeds.emplace_back("seed.digibyte.io"); // Jared Tate
-        vSeeds.emplace_back("seed.digihash.co"); // Jared Tate
-        vSeeds.emplace_back("dnsseed.esotericizm.site"); // DigiContributor
-        vSeeds.emplace_back("seed.digibytefoundation.org"); // DigiByte Foundation
-        vSeeds.emplace_back("seed.digiexplorer.info"); // DigiByte Foundation
-        vSeeds.emplace_back("seed.digiassets.net"); // DigiByte Foundation
-        vSeeds.emplace_back("digibyteblockexplorer.com"); // DigiByte Block Explorer
-        vSeeds.emplace_back("dgb1.trezor.io"); // Trezor
-        vSeeds.emplace_back("seed2.digibyte.io"); // Jared Tate
-        vSeeds.emplace_back("seed3.digibyte.io"); // Jared Tate
-        vSeeds.emplace_back("seed.digibyteblockchain.com"); // JS555
-        vSeeds.emplace_back("seed.digibyte.host"); // SashaD
-        vSeeds.emplace_back("seed.digibyteservers.io"); // ChillingSilence
-        vSeeds.emplace_back("seed.digibyte.help"); // Olly Stedall @saltedlolly
+        // The current list of DigiByte Seeders and who maintains them can be found pinned to the top of
+        // the DGBCIT Telegram group: https://t.me/DGBCIT
 
+        // When adding a new MAINNET Seeder URL below, please include the name of the person in charge of it
+        // and their Github handle so they can be contacted in an emergency.
+
+        // DigiByte MAINNET DNS Seeders:
+        vSeeds.emplace_back("seed.digibyte.io"); // Jared Tate @JaredTate
+        vSeeds.emplace_back("seed.digibyte.help"); // Olly Stedall @saltedlolly 
+        vSeeds.emplace_back("seed.digibyteblockchain.org"); // John Song @j50ng
+        vSeeds.emplace_back("seed.digibyte.org"); // Website collective [This will likely be removed if we cannot establish who maintains it.]
+
+        // DigiByte MAINNET Full Nodes: (These will eventually be removed to be replaced with genuine DigiByte Seeders above.)
+        vSeeds.emplace_back("seed2.digibyte.io"); // Jared Tate
+        vSeeds.emplace_back("seed.digibyte.host"); // SashaD
 
         base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1,30);
         base58Prefixes[SCRIPT_ADDRESS_OLD] = std::vector<unsigned char>(1,5);
@@ -406,9 +404,18 @@ public:
 
         vFixedSeeds.clear();
         vSeeds.clear();
+
+        // The current list of DigiByte Seeders and who maintains them can be found pinned to the top of
+        // the DGBCIT Telegram group: https://t.me/DGBCIT
+
+        // When adding a new TESTNET Seeder URL below, please include the name of the person in charge of it
+        // and their Github handle so they can be contacted in an emergency.
+
         // nodes with support for servicebits filtering should be at the top
-        vSeeds.emplace_back("seed.testnet-1.us.digibyteservers.io");
-        vSeeds.emplace_back("seed.testnetexplorer.digibyteservers.io");
+
+        // DigiByte TESTNET DNS Seeders:
+        vSeeds.emplace_back("testnetseed.digibyte.help"); // Olly Stedall @saltedlolly 
+        vSeeds.emplace_back("testseed.digibyteblockchain.org"); // John Song @j50ng
 
         base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1,126);
         base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1,140);


### PR DESCRIPTION
I have removed all the non-functioning seeders after testing all of them. The list is here: https://1drv.ms/w/s!AsTGLNLt5YBypgS8ljrD5-aSSqol

Many of these were not actually DNS Seeders but full nodes. Regardless, any that are no longer functioning, I have removed. The plan is to replace all the current full nodes in this list with genuine DNS Seeders, with each one run by a different member of the community, distributed around the globe. Over the last few weeks, we have been finding volunteers to do this. For better redundancy, each Seeder has a single person in charge of it, and each person may only run a single mainnet and/or testnet Seeder.

Everyone setting up a Seeder will be making their own PR to add theirs to DigiByte Core. All these will be DNS Seeders and NOT full nodes (though they can run a full node on the same server if they desire). This is the same way Bitcoin does it: https://github.com/bitcoin/bitcoin/blob/07ce278455757fb46dab95fb9b97a3f6b1b84faf/src/chainparams.cpp#L132

I have added some guidelines on how people should add their Seeder, requesting they include their name and Github handle so everyone knows who to contact in the event of a problem with the Seeder.

I have also added the testnet seeders recently set up by myself and @j50ng since none of the original testnet seeders are working anymore. This will get the testnet functioning properly again, at least for this branch. We already have two additional testnet Seeders already up and running, but they will be added in a PR from the people running them.

The new list of DigiByte Seeders (mainnet and testnet) and who is managing them can be seen here: https://1drv.ms/w/s!AsTGLNLt5YBypgadXSi16NEPaXes

We still have a few more Seeders to add around the world. If anyone can help by running one, please get in touch in the DGBCIT Telegram group: https://t.me/DGBCIT