### PR TITLE
Disable taproot until we find a solution to prevent chain bloats

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -379,8 +379,8 @@ public:
 
         // Deployment of Taproot (BIPs 340-342)
         consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].bit = 2;
-        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].nStartTime = 1630454400; // Sept 1st, 2021
-        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].nTimeout = 1664582400; // October 1st, 2021
+        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].nStartTime = 4070908800; // January 1st, 2099
+        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].nTimeout = 4099766400; // December 1st, 2099
         consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].min_activation_height = 0; // No activation delay
 
         consensus.nOdoShapechangeInterval = 1*24*60*60; // 1 day
@@ -690,9 +690,10 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].min_activation_height = 0; // No activation delay
 
+        // Deployment of Taproot (BIPs 340-342)
         consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].bit = 2;
-        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].nStartTime = Consensus::BIP9Deployment::ALWAYS_ACTIVE;
-        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
+        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].nStartTime = 4070908800; // January 1st, 2099
+        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].nTimeout = 4099766400; // December 1st, 2099
         consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].min_activation_height = 0; // No activation delay
 
         consensus.nMinimumChainWork = uint256{};

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -107,8 +107,8 @@ public:
 
         // Deployment of Taproot (BIPs 340-342)
         consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].bit = 2;
-        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].nStartTime = 1630454400; // Sept 1st, 2021
-        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].nTimeout = 1664582400; // October 1st, 2021
+        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].nStartTime = 4070908800; // January 1st, 2099
+        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].nTimeout = 4099766400; // December 1st, 2099
         consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].min_activation_height = 0; // No activation delay
 
         // The best chain should have at least this much work.

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1569,7 +1569,6 @@ RPCHelpMan getblockchaininfo()
     SoftForkDescPushBack(tip, softforks, consensusParams, Consensus::DEPLOYMENT_SEGWIT);
     SoftForkDescPushBack(tip, softforks, consensusParams, Consensus::DEPLOYMENT_TESTDUMMY);
     SoftForkDescPushBack(tip, softforks, consensusParams, Consensus::DEPLOYMENT_ODO);
-    SoftForkDescPushBack(tip, softforks, consensusParams, Consensus::DEPLOYMENT_TAPROOT);
     obj.pushKV("softforks", softforks);
     obj.pushKV("warnings", GetWarnings(false).original);
     return obj;


### PR DESCRIPTION
### This PR effectively disables taproot by setting it's activation date to year 2099.

We effectively disabled the activation by postponing it (instead of removing all taproot related code) so that we can easily reintroduce it in a future release when we have a fix ready to prevent the blockchain bloat that is happening on other chains right now. Additionally, this has the positive side effect that the functional tests regarding the activation of taproot will remain working.

#### Author's note
I am all for NFTs but it makes much more sense to store secure cryptographic hashes of your data instead of the raw data itself.





