### PR TITLE
Fix tests related to subsidy

### DIFF
--- a/src/test/validation_tests.cpp
+++ b/src/test/validation_tests.cpp
@@ -174,7 +174,7 @@ static void TestBlockSubsidy(const Consensus::Params& consensusParams, int nMaxB
     }
 
     CAmount nSubsidy = GetBlockSubsidy(nMaxBlocks, consensusParams);
-    CAmount nExpectedSubsidy = 1 * COIN;
+    CAmount nExpectedSubsidy = 0 * COIN;
 
     BOOST_CHECK_EQUAL(nSubsidy, nExpectedSubsidy);
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1201,7 +1201,6 @@ CTransactionRef GetTransaction(const CBlockIndex* const block_index, const CTxMe
 CAmount GetBlockSubsidy(int nHeight, const Consensus::Params& consensusParams)
 {
     CAmount nSubsidy = COIN;
-    LogPrintf("block height for reward is %d\n", nHeight);
 
     if (nHeight < consensusParams.nDiffChangeTarget) { // < 67200
         if (nHeight < 1440)


### PR DESCRIPTION
### This PR fixes the log bloat happening due to a log statement in `GetBlockSubsidy`
First, this PR removes the log statement from the function `GetBlockSubsidy` in src/validation.cpp and second it adjusts the expected subsidy to zero (after all block rewards have been paid).