### PR TITLE
Bump TX Fees to Match DEFAULT_MIN_RELAY_TX_FEE & Fix Relay Issue

### DIFF
--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -22,7 +22,7 @@ static const unsigned int DEFAULT_BLOCK_PRIORITY_SIZE = 0;
 /** Default for -blockmaxweight, which controls the range of block weights the mining code will create **/
 static const unsigned int DEFAULT_BLOCK_MAX_WEIGHT = MAX_BLOCK_WEIGHT - 4000;
 /** Default for -blockmintxfee, which sets the minimum feerate for a transaction in blocks created by mining code **/
-static const unsigned int DEFAULT_BLOCK_MIN_TX_FEE = 1000;
+static const unsigned int DEFAULT_BLOCK_MIN_TX_FEE = 10000;
 /** The maximum weight for transactions we're willing to relay/mine */
 static const unsigned int MAX_STANDARD_TX_WEIGHT = 400000;
 /** The minimum non-witness size for transactions we're willing to relay/mine (1 segwit input + 1 P2WPKH output = 82 bytes) */
@@ -34,7 +34,7 @@ static const unsigned int MAX_STANDARD_TX_SIGOPS_COST = MAX_BLOCK_SIGOPS_COST/5;
 /** Default for -maxmempool, maximum megabytes of mempool memory usage */
 static const unsigned int DEFAULT_MAX_MEMPOOL_SIZE = 300;
 /** Default for -incrementalrelayfee, which sets the minimum feerate increase for mempool limiting or BIP 125 replacement **/
-static const unsigned int DEFAULT_INCREMENTAL_RELAY_FEE = 1000;
+static const unsigned int DEFAULT_INCREMENTAL_RELAY_FEE = 10000;
 /** Default for -bytespersigop */
 static const unsigned int DEFAULT_BYTES_PER_SIGOP = 20;
 /** Default for -permitbaremultisig */
@@ -54,7 +54,7 @@ static const unsigned int MAX_STANDARD_SCRIPTSIG_SIZE = 1650;
  * standard and should be done with care and ideally rarely. It makes sense to
  * only increase the dust limit after prior releases were already not creating
  * outputs below the new threshold */
-static const unsigned int DUST_RELAY_TX_FEE = 3000;
+static const unsigned int DUST_RELAY_TX_FEE = 30000;
 /**
  * Standard script verification flags that standard transactions will comply
  * with. However scripts violating these flags may still be present in valid

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -22,7 +22,7 @@ static const unsigned int DEFAULT_BLOCK_PRIORITY_SIZE = 0;
 /** Default for -blockmaxweight, which controls the range of block weights the mining code will create **/
 static const unsigned int DEFAULT_BLOCK_MAX_WEIGHT = MAX_BLOCK_WEIGHT - 4000;
 /** Default for -blockmintxfee, which sets the minimum feerate for a transaction in blocks created by mining code **/
-static const unsigned int DEFAULT_BLOCK_MIN_TX_FEE = 10000;
+static const unsigned int DEFAULT_BLOCK_MIN_TX_FEE = 100000;
 /** The maximum weight for transactions we're willing to relay/mine */
 static const unsigned int MAX_STANDARD_TX_WEIGHT = 400000;
 /** The minimum non-witness size for transactions we're willing to relay/mine (1 segwit input + 1 P2WPKH output = 82 bytes) */


### PR DESCRIPTION
This PR increases min tx fee in other code to match the previous increase we made with `DEFAULT_MIN_RELAY_TX_FEE`. The increase was also needed with `DEFAULT_BLOCK_MIN_TX_FEE` & `DEFAULT_INCREMENTAL_RELAY_FEE` & `DUST_RELAY_TX_FEE` proportionally to what they were before. This should solve the testnet mining issue with block tx's not getting relayed because of low fees. https://github.com/DigiByte-Core/digibyte/issues/147

I have not test-mined these changes to verify this fixes the mempool relay issue, so it would be great to get some help doing this with a mining pool on testnet. But this "should" fix it. We may have to change 1 or 2 other places as well.

Here is the current code without these changes & explanation for what is going on:
https://github.com/DigiByte-Core/digibyte/blob/b75fea614b5e86f89a4759cdcfdc8d38635b50cf/src/validation.h#L73


https://github.com/DigiByte-Core/digibyte/blob/b75fea614b5e86f89a4759cdcfdc8d38635b50cf/src/policy/policy.h#L25

It looks like `DEFAULT_BLOCK_MIN_TX_FEE`  is called in BlockAssembler, so its being assembled with lower fees, then getting rejected by  `PeerManagerImpl::MaybeSendFeefilter` where `DEFAULT_MIN_RELAY_TX_FEE`  is called. 
https://github.com/DigiByte-Core/digibyte/blob/b75fea614b5e86f89a4759cdcfdc8d38635b50cf/src/miner.cpp#L56-L59

`PeerManagerImpl::MaybeSendFeefilter` calls `DEFAULT_MIN_RELAY_TX_FEE`  and filters out TXs without high enough fees, that's why they sit in mempool. Block assembler not including high enough fee.
https://github.com/DigiByte-Core/digibyte/blob/b75fea614b5e86f89a4759cdcfdc8d38635b50cf/src/net_processing.cpp#L4528-L4539

We should probably update these below too:

https://github.com/DigiByte-Core/digibyte/blob/b75fea614b5e86f89a4759cdcfdc8d38635b50cf/src/policy/policy.h#L37


https://github.com/DigiByte-Core/digibyte/blob/b75fea614b5e86f89a4759cdcfdc8d38635b50cf/src/policy/policy.h#L57