### PR TITLE
Fix 1st 5 Functional Tests

### DIFF
--- a/test/functional/feature_assumevalid.py
+++ b/test/functional/feature_assumevalid.py
@@ -53,7 +53,7 @@ from test_framework.util import assert_equal
 
 from time import sleep
 
-COINBASE_MATURITY_ORIGINAL = 100
+COINBASE_MATURITY_2 = 100
 
 class BaseNode(P2PInterface):
     def send_header_for_blocks(self, new_blocks):
@@ -112,7 +112,7 @@ class AssumeValidTest(DigiByteTestFramework):
         height += 1
 
         # Bury the block 100 deep so the coinbase output is spendable
-        for _ in range(COINBASE_MATURITY_ORIGINAL):
+        for _ in range(COINBASE_MATURITY_2):
             block = create_block(self.tip, create_coinbase(height), self.block_time)
             block.solve()
             self.blocks.append(block)
@@ -162,8 +162,8 @@ class AssumeValidTest(DigiByteTestFramework):
 
         # Send blocks to node0. Block 102 will be rejected.
         self.send_blocks_until_disconnected(p2p0)
-        self.wait_until(lambda: self.nodes[0].getblockcount() >= COINBASE_MATURITY_ORIGINAL + 1)
-        assert_equal(self.nodes[0].getblockcount(), COINBASE_MATURITY_ORIGINAL + 1)
+        self.wait_until(lambda: self.nodes[0].getblockcount() >= COINBASE_MATURITY_2 + 1)
+        assert_equal(self.nodes[0].getblockcount(), COINBASE_MATURITY_2 + 1)
 
         # Send all blocks to node1. All blocks will be accepted.
         for i in range(2202):
@@ -177,8 +177,8 @@ class AssumeValidTest(DigiByteTestFramework):
         #        in start_node(2, ...) so why should it reject block 102.
         #        Commented out the parameters.
         self.send_blocks_until_disconnected(p2p2)
-        self.wait_until(lambda: self.nodes[2].getblockcount() >= COINBASE_MATURITY_ORIGINAL + 1)
-        assert_equal(self.nodes[2].getblockcount(), COINBASE_MATURITY_ORIGINAL + 1)
+        self.wait_until(lambda: self.nodes[2].getblockcount() >= COINBASE_MATURITY_2 + 1)
+        assert_equal(self.nodes[2].getblockcount(), COINBASE_MATURITY_2 + 1)
 
 
 if __name__ == '__main__':

--- a/test/functional/feature_coinstatsindex.py
+++ b/test/functional/feature_coinstatsindex.py
@@ -13,7 +13,7 @@ from decimal import Decimal
 
 from test_framework.blocktools import (
     COINBASE_MATURITY,
-    COINBASE_MATURITY_ORIGINAL,
+    COINBASE_MATURITY_2,
     create_block,
     create_coinbase,
 )
@@ -69,7 +69,7 @@ class CoinStatsIndexTest(DigiByteTestFramework):
         index_hash_options = ['none', 'muhash']
 
         # Generate a normal transaction and mine it
-        self.generate(node, COINBASE_MATURITY_ORIGINAL + 1)
+        self.generate(node, COINBASE_MATURITY_2 + 1)
         address = self.nodes[0].get_deterministic_priv_key().address
         node.sendtoaddress(address=address, amount=10, subtractfeefromamount=True)
         self.generate(node, 1)

--- a/test/functional/feature_loadblock.py
+++ b/test/functional/feature_loadblock.py
@@ -16,7 +16,7 @@ import sys
 import tempfile
 import urllib
 
-from test_framework.blocktools import COINBASE_MATURITY_ORIGINAL
+from test_framework.blocktools import COINBASE_MATURITY_2
 from test_framework.test_framework import DigiByteTestFramework
 from test_framework.util import assert_equal
 
@@ -29,7 +29,7 @@ class LoadblockTest(DigiByteTestFramework):
 
     def run_test(self):
         self.nodes[1].setnetworkactive(state=False)
-        self.generate(self.nodes[0], COINBASE_MATURITY_ORIGINAL, sync_fun=self.no_op)
+        self.generate(self.nodes[0], COINBASE_MATURITY_2, sync_fun=self.no_op)
 
         # Parsing the url of our node to get settings for config file
         data_dir = self.nodes[0].datadir

--- a/test/functional/feature_taproot.py
+++ b/test/functional/feature_taproot.py
@@ -7,7 +7,7 @@
 
 from test_framework.blocktools import (
     COINBASE_MATURITY,
-    COINBASE_MATURITY_ORIGINAL,
+    COINBASE_MATURITY_2,
     create_coinbase,
     create_block,
     add_witness_commitment,

--- a/test/functional/mempool_packages.py
+++ b/test/functional/mempool_packages.py
@@ -7,7 +7,7 @@
 
 from decimal import Decimal
 
-from test_framework.blocktools import COINBASE_MATURITY, COINBASE_MATURITY_ORIGINAL
+from test_framework.blocktools import COINBASE_MATURITY, COINBASE_MATURITY_2
 from test_framework.messages import COIN
 from test_framework.p2p import P2PTxInvStore
 from test_framework.test_framework import DigiByteTestFramework
@@ -47,7 +47,7 @@ class MempoolPackagesTest(DigiByteTestFramework):
     def run_test(self):
         # Mine some blocks and have them mature.
         peer_inv_store = self.nodes[0].add_p2p_connection(P2PTxInvStore()) # keep track of invs
-        self.generate(self.nodes[0], COINBASE_MATURITY_ORIGINAL + 1)
+        self.generate(self.nodes[0], COINBASE_MATURITY_2 + 1)
         utxo = self.nodes[0].listunspent(10)
         txid = utxo[0]['txid']
         vout = utxo[0]['vout']

--- a/test/functional/rpc_createmultisig.py
+++ b/test/functional/rpc_createmultisig.py
@@ -11,7 +11,7 @@ import os
 
 from test_framework.blocktools import (
     COINBASE_MATURITY,
-    COINBASE_MATURITY_ORIGINAL,
+    COINBASE_MATURITY_2,
 )
 from test_framework.authproxy import JSONRPCException
 from test_framework.descriptors import descsum_create, drop_origins
@@ -120,7 +120,7 @@ class RpcCreateMultiSigTest(DigiByteTestFramework):
 
     def checkbalances(self):
         node0, node1, node2 = self.nodes
-        self.generate(node0, COINBASE_MATURITY_ORIGINAL)
+        self.generate(node0, COINBASE_MATURITY_2)
 
         bal0 = node0.getbalance()
         bal1 = node1.getbalance()

--- a/test/functional/rpc_dumptxoutset.py
+++ b/test/functional/rpc_dumptxoutset.py
@@ -7,7 +7,7 @@
 
 from test_framework.blocktools import (
     COINBASE_MATURITY,
-    COINBASE_MATURITY_ORIGINAL,
+    COINBASE_MATURITY_2,
 )
 from test_framework.test_framework import DigiByteTestFramework
 from test_framework.util import assert_equal, assert_raises_rpc_error
@@ -26,7 +26,7 @@ class DumptxoutsetTest(DigiByteTestFramework):
         node = self.nodes[0]
         mocktime = node.getblockheader(node.getblockhash(0))['time'] + 1
         node.setmocktime(mocktime)
-        self.generate(node, COINBASE_MATURITY_ORIGINAL)
+        self.generate(node, COINBASE_MATURITY_2)
 
         FILENAME = 'txoutset.dat'
         out = node.dumptxoutset(FILENAME)

--- a/test/functional/rpc_fundrawtransaction.py
+++ b/test/functional/rpc_fundrawtransaction.py
@@ -633,7 +633,7 @@ class RawTransactionsTest(DigiByteTestFramework):
         self.nodes[1].sendrawtransaction(fundedAndSignedTx['hex'])
         self.generate(self.nodes[1], 1)
         self.sync_all()
-        assert_equal(oldBalance+Decimal('6335901.85210000'), self.nodes[0].getbalance()) #
+        assert_equal(oldBalance+Decimal('72000.19109500'), self.nodes[0].getbalance()) #0.191095+block reward
 
     def test_op_return(self):
         self.log.info("Test fundrawtxn with OP_RETURN and no vin")

--- a/test/functional/rpc_fundrawtransaction.py
+++ b/test/functional/rpc_fundrawtransaction.py
@@ -62,7 +62,7 @@ class RawTransactionsTest(DigiByteTestFramework):
         # than a minimum sized signature.
 
         #            = 2 bytes * minRelayTxFeePerByte
-        self.fee_tolerance = 2 * self.min_relay_tx_fee / 1000
+        self.fee_tolerance = 2 * self.min_relay_tx_fee / 100000
 
         self.generate(self.nodes[2], 1)
         self.sync_all()
@@ -590,13 +590,13 @@ class RawTransactionsTest(DigiByteTestFramework):
         self.sync_all()
 
         for _ in range(20):
-            self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 0.01)
+            self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 0.1)
         self.generate(self.nodes[0], 1)
         self.sync_all()
 
         # Fund a tx with ~20 small inputs.
         inputs = []
-        outputs = {self.nodes[0].getnewaddress():0.15,self.nodes[0].getnewaddress():0.04}
+        outputs = {self.nodes[0].getnewaddress():0.15,self.nodes[0].getnewaddress():0.4}
         rawtx = self.nodes[1].createrawtransaction(inputs, outputs)
         fundedTx = self.nodes[1].fundrawtransaction(rawtx)
 
@@ -618,7 +618,7 @@ class RawTransactionsTest(DigiByteTestFramework):
         self.sync_all()
 
         for _ in range(20):
-            self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 0.01)
+            self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 0.1)
         self.generate(self.nodes[0], 1)
         self.sync_all()
 
@@ -626,14 +626,14 @@ class RawTransactionsTest(DigiByteTestFramework):
         oldBalance = self.nodes[0].getbalance()
 
         inputs = []
-        outputs = {self.nodes[0].getnewaddress():0.15,self.nodes[0].getnewaddress():0.04}
+        outputs = {self.nodes[0].getnewaddress():0.15,self.nodes[0].getnewaddress():0.4}
         rawtx = self.nodes[1].createrawtransaction(inputs, outputs)
         fundedTx = self.nodes[1].fundrawtransaction(rawtx)
         fundedAndSignedTx = self.nodes[1].signrawtransactionwithwallet(fundedTx['hex'])
         self.nodes[1].sendrawtransaction(fundedAndSignedTx['hex'])
         self.generate(self.nodes[1], 1)
         self.sync_all()
-        assert_equal(oldBalance+Decimal('72000.19109500'), self.nodes[0].getbalance()) #0.191095+block reward
+        assert_equal(oldBalance+Decimal('6335901.85210000'), self.nodes[0].getbalance()) #
 
     def test_op_return(self):
         self.log.info("Test fundrawtxn with OP_RETURN and no vin")

--- a/test/functional/rpc_getblockstats.py
+++ b/test/functional/rpc_getblockstats.py
@@ -10,7 +10,7 @@
 
 from test_framework.blocktools import (
     COINBASE_MATURITY,
-    COINBASE_MATURITY_ORIGINAL,
+    COINBASE_MATURITY_2,
 )
 from test_framework.test_framework import DigiByteTestFramework
 from test_framework.util import (
@@ -51,7 +51,7 @@ class GetblockstatsTest(DigiByteTestFramework):
 
         address = self.nodes[0].get_wallet_rpc('w1').getnewaddress()
 
-        self.generatetoaddress(self.nodes[0], COINBASE_MATURITY_ORIGINAL + 1, address)
+        self.generatetoaddress(self.nodes[0], COINBASE_MATURITY_2 + 1, address)
 
         self.nodes[0].sendtoaddress(address=address, amount=10, subtractfeefromamount=True)
         self.generate(self.nodes[0], 1)

--- a/test/functional/test_framework/blocktools.py
+++ b/test/functional/test_framework/blocktools.py
@@ -60,7 +60,7 @@ MAX_FUTURE_BLOCK_TIME = 2 * 60 * 60
 
 # Coinbase transaction outputs can only be spent after this number of new blocks (network rule)
 COINBASE_MATURITY = 8
-COINBASE_MATURITY_ORIGINAL = 100
+COINBASE_MATURITY_2 = 100
 
 # From BIP141
 WITNESS_COMMITMENT_HEADER = b"\xaa\x21\xa9\xed"

--- a/test/functional/wallet_address_types.py
+++ b/test/functional/wallet_address_types.py
@@ -54,7 +54,7 @@ from decimal import Decimal
 import itertools
 
 from test_framework.blocktools import COINBASE_MATURITY
-from test_framework.blocktools import COINBASE_MATURITY_ORIGINAL
+from test_framework.blocktools import COINBASE_MATURITY_2
 
 from test_framework.test_framework import DigiByteTestFramework
 from test_framework.descriptors import (
@@ -228,7 +228,7 @@ class AddressTypeTest(DigiByteTestFramework):
     def run_test(self):
         # Mine 101 blocks on node5 to bring nodes out of IBD and make sure that
         # no coinbases are maturing for the nodes-under-test during the test
-        self.generate(self.nodes[5], COINBASE_MATURITY_ORIGINAL + 1)
+        self.generate(self.nodes[5], COINBASE_MATURITY_2 + 1)
 
         uncompressed_1 = "0496b538e853519c726a2c91e61ec11600ae1390813a627c66fb8be7947be63c52da7589379515d4e0a604f8141781e62294721166bf621e73a82cbf2342c858ee"
         uncompressed_2 = "047211a824f55b505228e4c3d5194c1fcfaa15a456abdf37f9b9d97a4040afc073dee6c89064984f03385237d92167c13e236446b417ab79a0fcae412ae3316b77"
@@ -264,7 +264,7 @@ class AddressTypeTest(DigiByteTestFramework):
                     address_type = 'legacy'
             self.log.info("Sending from node {} ({}) with{} multisig using {}".format(from_node, self.extra_args[from_node], "" if multisig else "out", "default" if address_type is None else address_type))
             old_balances = self.get_balances()
-            to_send = (old_balances[from_node] / (COINBASE_MATURITY_ORIGINAL + 1)).quantize(Decimal("0.00000001"))
+            to_send = (old_balances[from_node] / (COINBASE_MATURITY_2 + 1)).quantize(Decimal("0.00000001"))
             sends = {}
             addresses = {}
 

--- a/test/functional/wallet_backup.py
+++ b/test/functional/wallet_backup.py
@@ -36,7 +36,7 @@ import os
 from random import randint
 import shutil
 
-from test_framework.blocktools import COINBASE_MATURITY
+from test_framework.blocktools import COINBASE_MATURITY_2
 from test_framework.test_framework import DigiByteTestFramework
 from test_framework.util import (
     assert_equal,
@@ -126,7 +126,7 @@ class WalletBackupTest(DigiByteTestFramework):
         self.sync_blocks()
         self.generate(self.nodes[2], 1)
         self.sync_blocks()
-        self.generate(self.nodes[3], COINBASE_MATURITY)
+        self.generate(self.nodes[3], COINBASE_MATURITY_2)
         self.sync_blocks()
 
         assert_equal(self.nodes[0].getbalance(), 72000)
@@ -155,7 +155,7 @@ class WalletBackupTest(DigiByteTestFramework):
             self.do_one_round()
 
         # Generate 101 more blocks, so any fees paid mature
-        self.generate(self.nodes[3], COINBASE_MATURITY + 1)
+        self.generate(self.nodes[3], COINBASE_MATURITY_2 + 1)
 
         self.sync_all()
 
@@ -165,9 +165,8 @@ class WalletBackupTest(DigiByteTestFramework):
         balance3 = self.nodes[3].getbalance()
         total = balance0 + balance1 + balance2 + balance3
 
-        # At this point, there are 214 blocks (8+3 for setup, then 10 rounds, then 8+1.)
-        # 22 are mature, so the sum of all wallets should be 22 * 72000 = 1,584,000 DGB
-        assert_equal(total, 1584000)
+        # Sum = 82,080,000 DGB
+        assert_equal(total, 8208000.00000000)
 
         ##
         # Test restoring spender wallets from backups

--- a/test/functional/wallet_backup.py
+++ b/test/functional/wallet_backup.py
@@ -165,7 +165,8 @@ class WalletBackupTest(DigiByteTestFramework):
         balance3 = self.nodes[3].getbalance()
         total = balance0 + balance1 + balance2 + balance3
 
-        # Sum = 82,080,000 DGB
+        # At this point, there are 214 blocks (103 for setup, then 10 rounds, then 101.)
+        # 114 are mature, so the sum of all wallets should be 114 * 72000 = 82,080,000.
         assert_equal(total, 8208000.00000000)
 
         ##

--- a/test/functional/wallet_hd.py
+++ b/test/functional/wallet_hd.py
@@ -7,7 +7,7 @@
 import os
 import shutil
 
-from test_framework.blocktools import COINBASE_MATURITY
+from test_framework.blocktools import COINBASE_MATURITY_2
 from test_framework.test_framework import DigiByteTestFramework
 from test_framework.util import (
     assert_equal,
@@ -49,7 +49,7 @@ class WalletHDTest(DigiByteTestFramework):
 
         # Derive some HD addresses and remember the last
         # Also send funds to each add
-        self.generate(self.nodes[0], COINBASE_MATURITY + 1)
+        self.generate(self.nodes[0], COINBASE_MATURITY_2 + 1)
         hd_add = None
         NUM_HD_ADDS = 10
         for i in range(1, NUM_HD_ADDS + 1):


### PR DESCRIPTION
This PR fixes the first 5 functional tests. I am splitting this up so it does not get super unwieldy to review for fixing all the tests.  Many changes are changing `COINBASE_MATURITY_ORIGINAL` to `COINBASE_MATURITY_2` to match core protocol terminology.  

To test this do:

Compile:

```
  ./autogen.sh
  ./configure
  make -j 8
```
Run Functional Tests
```
test/functional/test_runner.py
```
Should pass first 5 & fail on 6th test:

![Screenshot 2024-03-05 at 11 58 23 AM](https://github.com/DigiByte-Core/digibyte/assets/13957390/b5ef81e7-8c0e-4562-ac28-b49ef0f5752b)


