### PR TITLE
Fix 5 Functional Tests

### DIFF
--- a/test/functional/p2p_compactblocks.py
+++ b/test/functional/p2p_compactblocks.py
@@ -10,7 +10,7 @@ Version 2 compact blocks are post-segwit (wtxids)
 import random
 
 from test_framework.blocktools import (
-    COINBASE_MATURITY,
+    COINBASE_MATURITY_2,
     NORMAL_GBT_REQUEST_PARAMS,
     add_witness_commitment,
     create_block,
@@ -165,7 +165,7 @@ class CompactBlocksTest(DigiByteTestFramework):
         block = self.build_block_on_tip(self.nodes[0])
         self.segwit_node.send_and_ping(msg_no_witness_block(block))
         assert int(self.nodes[0].getbestblockhash(), 16) == block.sha256
-        self.generatetoaddress(self.nodes[0], COINBASE_MATURITY, self.nodes[0].getnewaddress(address_type="bech32"))
+        self.generatetoaddress(self.nodes[0], COINBASE_MATURITY_2, self.nodes[0].getnewaddress(address_type="bech32"))
 
         total_value = block.vtx[0].vout[0].nValue
         out_value = total_value // 10
@@ -276,7 +276,7 @@ class CompactBlocksTest(DigiByteTestFramework):
 
     # This test actually causes bitcoind to (reasonably!) disconnect us, so do this last.
     def test_invalid_cmpctblock_message(self):
-        self.generate(self.nodes[0], COINBASE_MATURITY + 1)
+        self.generate(self.nodes[0], COINBASE_MATURITY_2 + 1)
         block = self.build_block_on_tip(self.nodes[0])
 
         cmpct_block = P2PHeaderAndShortIDs()
@@ -294,7 +294,7 @@ class CompactBlocksTest(DigiByteTestFramework):
         version = test_node.cmpct_version
         node = self.nodes[0]
         # Generate a bunch of transactions.
-        self.generate(node, COINBASE_MATURITY + 1)
+        self.generate(node, COINBASE_MATURITY_2 + 1)
         num_transactions = 25
         address = node.getnewaddress()
 

--- a/test/functional/wallet_importmulti.py
+++ b/test/functional/wallet_importmulti.py
@@ -15,7 +15,7 @@ variants.
 - `test_address()` is called to call getaddressinfo for an address on node1
   and test the values returned."""
 
-from test_framework.blocktools import COINBASE_MATURITY
+from test_framework.blocktools import COINBASE_MATURITY_2
 from test_framework.script import (
     CScript,
     OP_NOP,
@@ -255,7 +255,7 @@ class ImportMultiTest(DigiByteTestFramework):
 
         # P2SH address
         multisig = get_multisig(self.nodes[0])
-        self.generate(self.nodes[1], COINBASE_MATURITY, sync_fun=self.no_op)
+        self.generate(self.nodes[1], COINBASE_MATURITY_2, sync_fun=self.no_op)
         self.nodes[1].sendtoaddress(multisig.p2sh_addr, 10.00)
         self.generate(self.nodes[1], 1, sync_fun=self.no_op)
         timestamp = self.nodes[1].getblock(self.nodes[1].getbestblockhash())['mediantime']
@@ -275,7 +275,7 @@ class ImportMultiTest(DigiByteTestFramework):
 
         # P2SH + Redeem script
         multisig = get_multisig(self.nodes[0])
-        self.generate(self.nodes[1], COINBASE_MATURITY, sync_fun=self.no_op)
+        self.generate(self.nodes[1], COINBASE_MATURITY_2, sync_fun=self.no_op)
         self.nodes[1].sendtoaddress(multisig.p2sh_addr, 10.00)
         self.generate(self.nodes[1], 1, sync_fun=self.no_op)
         timestamp = self.nodes[1].getblock(self.nodes[1].getbestblockhash())['mediantime']
@@ -295,7 +295,7 @@ class ImportMultiTest(DigiByteTestFramework):
 
         # P2SH + Redeem script + Private Keys + !Watchonly
         multisig = get_multisig(self.nodes[0])
-        self.generate(self.nodes[1], COINBASE_MATURITY, sync_fun=self.no_op)
+        self.generate(self.nodes[1], COINBASE_MATURITY_2, sync_fun=self.no_op)
         self.nodes[1].sendtoaddress(multisig.p2sh_addr, 10.00)
         self.generate(self.nodes[1], 1, sync_fun=self.no_op)
         timestamp = self.nodes[1].getblock(self.nodes[1].getbestblockhash())['mediantime']
@@ -320,7 +320,7 @@ class ImportMultiTest(DigiByteTestFramework):
 
         # P2SH + Redeem script + Private Keys + Watchonly
         multisig = get_multisig(self.nodes[0])
-        self.generate(self.nodes[1], COINBASE_MATURITY, sync_fun=self.no_op)
+        self.generate(self.nodes[1], COINBASE_MATURITY_2, sync_fun=self.no_op)
         self.nodes[1].sendtoaddress(multisig.p2sh_addr, 10.00)
         self.generate(self.nodes[1], 1, sync_fun=self.no_op)
         timestamp = self.nodes[1].getblock(self.nodes[1].getbestblockhash())['mediantime']

--- a/test/functional/wallet_keypool_topup.py
+++ b/test/functional/wallet_keypool_topup.py
@@ -13,7 +13,7 @@ Two nodes. Node1 is under test. Node0 is providing transactions and generating b
 import os
 import shutil
 
-from test_framework.blocktools import COINBASE_MATURITY
+from test_framework.blocktools import COINBASE_MATURITY_2
 from test_framework.test_framework import DigiByteTestFramework
 from test_framework.util import (
     assert_equal,
@@ -32,7 +32,7 @@ class KeypoolRestoreTest(DigiByteTestFramework):
     def run_test(self):
         wallet_path = os.path.join(self.nodes[1].datadir, self.chain, "wallets", self.default_wallet_name, self.wallet_data_filename)
         wallet_backup_path = os.path.join(self.nodes[1].datadir, "wallet.bak")
-        self.generate(self.nodes[0], COINBASE_MATURITY + 1)
+        self.generate(self.nodes[0], COINBASE_MATURITY_2 + 1)
 
         self.log.info("Make backup of wallet")
         self.stop_node(1)

--- a/test/functional/wallet_multiwallet.py
+++ b/test/functional/wallet_multiwallet.py
@@ -14,7 +14,7 @@ import stat
 import time
 
 from test_framework.authproxy import JSONRPCException
-from test_framework.blocktools import COINBASE_MATURITY
+from test_framework.blocktools import COINBASE_MATURITY_2
 from test_framework.test_framework import DigiByteTestFramework
 from test_framework.test_node import ErrorMatch
 from test_framework.util import (
@@ -230,7 +230,7 @@ class MultiWalletTest(DigiByteTestFramework):
         assert_raises_rpc_error(-19, "Wallet file not specified", node.getwalletinfo)
 
         w1, w2, w3, w4, *_ = wallets
-        self.generatetoaddress(node, nblocks=COINBASE_MATURITY + 1, address=w1.getnewaddress(), sync_fun=self.no_op)
+        self.generatetoaddress(node, nblocks=COINBASE_MATURITY_2 + 1, address=w1.getnewaddress(), sync_fun=self.no_op)
         assert_equal(w1.getbalance(), 72000 * 2)
         assert_equal(w2.getbalance(), 0)
         assert_equal(w3.getbalance(), 0)
@@ -251,9 +251,9 @@ class MultiWalletTest(DigiByteTestFramework):
         self.log.info('Check for per-wallet settxfee call')
         assert_equal(w1.getwalletinfo()['paytxfee'], 0)
         assert_equal(w2.getwalletinfo()['paytxfee'], 0)
-        w2.settxfee(0.001)
+        w2.settxfee(0.1)
         assert_equal(w1.getwalletinfo()['paytxfee'], 0)
-        assert_equal(w2.getwalletinfo()['paytxfee'], Decimal('0.00100000'))
+        assert_equal(w2.getwalletinfo()['paytxfee'], Decimal('0.100000'))
 
         self.log.info("Test dynamic wallet loading")
 

--- a/test/functional/wallet_orphanedreward.py
+++ b/test/functional/wallet_orphanedreward.py
@@ -6,7 +6,7 @@
 
 from test_framework.test_framework import DigiByteTestFramework
 from test_framework.util import assert_equal
-from test_framework.blocktools import COINBASE_MATURITY
+from test_framework.blocktools import COINBASE_MATURITY_2
 
 class OrphanedBlockRewardTest(DigiByteTestFramework):
     def set_test_params(self):
@@ -19,7 +19,7 @@ class OrphanedBlockRewardTest(DigiByteTestFramework):
     def run_test(self):
         # Generate some blocks and obtain some coins on node 0.  We send
         # some balance to node 1, which will hold it as a single coin.
-        self.generate(self.nodes[0], COINBASE_MATURITY + 50)
+        self.generate(self.nodes[0], COINBASE_MATURITY_2 + 50)
         self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 10)
         self.generate(self.nodes[0], 1)
 
@@ -30,14 +30,14 @@ class OrphanedBlockRewardTest(DigiByteTestFramework):
 
         # Let the block reward mature and send coins including both
         # the existing balance and the block reward.
-        self.generate(self.nodes[0], COINBASE_MATURITY + 50)
+        self.generate(self.nodes[0], COINBASE_MATURITY_2 + 50)
         assert_equal(self.nodes[1].getbalance(), 10 + 72000)
         txid = self.nodes[1].sendtoaddress(self.nodes[0].getnewaddress(), 30)
 
         # Orphan the block reward and make sure that the original coins
         # from the wallet can still be spent.
         self.nodes[0].invalidateblock(blk)
-        self.generate(self.nodes[0], COINBASE_MATURITY + 52)
+        self.generate(self.nodes[0], COINBASE_MATURITY_2 + 52)
 
         assert_equal(self.nodes[1].getbalances()["mine"], {
           "trusted": 10,


### PR DESCRIPTION
This PR fixes 5 functional tests. 

To test this:

Compile:

```
  ./autogen.sh
  ./configure
  make -j 8
```
Run Specific Functional Tests
```
test/functional/test_runner.py p2p_compactblocks.py
test/functional/test_runner.py wallet_importmulti.py
test/functional/test_runner.py wallet_keypool_topup.py
test/functional/test_runner.py wallet_multiwallet.py  
test/functional/test_runner.py wallet_orphanedreward.py
```

Or Run:

```
test/functional/test_runner.py p2p_compactblocks.py wallet_importmulti.py wallet_keypool_topup.py wallet_multiwallet.py  wallet_orphanedreward.py
```