### PR TITLE
Partial wallet_basic.py Fix & 5 other Functional Test Fixes

### DIFF
--- a/test/functional/interface_digibyte_cli.py
+++ b/test/functional/interface_digibyte_cli.py
@@ -8,7 +8,7 @@
 from decimal import Decimal
 import re
 
-from test_framework.blocktools import COINBASE_MATURITY
+from test_framework.blocktools import COINBASE_MATURITY_2
 from test_framework.test_framework import DigiByteTestFramework
 from test_framework.util import (
     assert_equal,
@@ -22,8 +22,8 @@ import time
 # The block reward of coinbaseoutput.nValue (72000) DGB/block matures after
 # COINBASE_MATURITY (100) blocks. Therefore, after mining 8+1 blocks we expect
 # node 0 to have a balance of (BLOCKS - COINBASE_MATURITY) * 72000 DGB/block.
-BLOCKS = COINBASE_MATURITY + 1
-BALANCE = (BLOCKS - COINBASE_MATURITY) * 72000
+BLOCKS = COINBASE_MATURITY_2 + 1
+BALANCE = (BLOCKS - COINBASE_MATURITY_2) * 72000
 
 JSON_PARSING_ERROR = 'error: Error parsing JSON: foo'
 BLOCKS_VALUE_OF_ZERO = 'error: the first argument (number of blocks to generate, default: 1) must be an integer value greater than zero'
@@ -156,7 +156,7 @@ class TestDigiByteCli(DigiByteTestFramework):
 
             # Setup to test -getinfo, -generate, and -rpcwallet= with multiple wallets.
             wallets = [self.default_wallet_name, 'Encrypted', 'secret']
-            amounts = [BALANCE + Decimal('9.99964000'), Decimal(9), Decimal(71981)]
+            amounts = [BALANCE + Decimal('9.96400000'), Decimal(9), Decimal(71981)]
             self.nodes[0].createwallet(wallet_name=wallets[1])
             self.nodes[0].createwallet(wallet_name=wallets[2])
             w1 = self.nodes[0].get_wallet_rpc(wallets[0])

--- a/test/functional/mempool_unbroadcast.py
+++ b/test/functional/mempool_unbroadcast.py
@@ -31,7 +31,7 @@ class MempoolUnbroadcastTest(DigiByteTestFramework):
         self.log.info("Test that mempool reattempts delivery of locally submitted transaction")
         node = self.nodes[0]
 
-        min_relay_fee = node.getnetworkinfo()["relayfee"]
+        min_relay_fee = 0.1
         utxos = create_confirmed_utxos(self, min_relay_fee, node, 10)
 
         self.disconnect_nodes(0, 1)
@@ -40,12 +40,12 @@ class MempoolUnbroadcastTest(DigiByteTestFramework):
 
         # generate a wallet txn
         addr = node.getnewaddress()
-        wallet_tx_hsh = node.sendtoaddress(addr, 0.001)
+        wallet_tx_hsh = node.sendtoaddress(addr, 0.1)
 
         # generate a txn using sendrawtransaction
         us0 = utxos.pop()
         inputs = [{"txid": us0["txid"], "vout": us0["vout"]}]
-        outputs = {addr: 0.001}
+        outputs = {addr: 0.1}
         tx = node.createrawtransaction(inputs, outputs)
         node.settxfee(min_relay_fee)
         txF = node.fundrawtransaction(tx)
@@ -103,7 +103,7 @@ class MempoolUnbroadcastTest(DigiByteTestFramework):
         # since the node doesn't have any connections, it will not receive
         # any GETDATAs & thus the transaction will remain in the unbroadcast set.
         addr = node.getnewaddress()
-        txhsh = node.sendtoaddress(addr, 0.0001)
+        txhsh = node.sendtoaddress(addr, 0.1)
 
         # check transaction was removed from unbroadcast set due to presence in
         # a block

--- a/test/functional/mining_basic.py
+++ b/test/functional/mining_basic.py
@@ -94,7 +94,7 @@ class MiningTest(DigiByteTestFramework):
         assert 'currentblocktx' not in mining_info
         assert 'currentblockweight' not in mining_info
         assert_equal(mining_info['difficulties']['scrypt'], Decimal('4.656542373906925E-10'))
-        assert_equal(mining_info['networkhashps'], Decimal('0.1333333333333333'))
+        assert_equal(mining_info['networkhashps'], Decimal('0.1344444444444444'))
         assert_equal(mining_info['pooledtx'], 0)
 
         self.log.info("getblocktemplate: Test default witness commitment")

--- a/test/functional/rpc_signrawtransaction.py
+++ b/test/functional/rpc_signrawtransaction.py
@@ -5,7 +5,7 @@
 """Test transaction signing using the signrawtransaction* RPCs."""
 
 from test_framework.blocktools import (
-    COINBASE_MATURITY,
+    COINBASE_MATURITY_2,
 )
 from test_framework.address import (
     script_to_p2sh,
@@ -181,7 +181,7 @@ class SignRawTransactionsTest(DigiByteTestFramework):
     def test_fully_signed_tx(self):
         self.log.info("Test signing a fully signed transaction does nothing")
         self.nodes[0].walletpassphrase("password", 9999)
-        self.generate(self.nodes[0], COINBASE_MATURITY + 1)
+        self.generate(self.nodes[0], COINBASE_MATURITY_2 + 1)
         rawtx = self.nodes[0].createrawtransaction([], [{self.nodes[0].getnewaddress(): 10}])
         fundedtx = self.nodes[0].fundrawtransaction(rawtx)
         signedtx = self.nodes[0].signrawtransactionwithwallet(fundedtx["hex"])
@@ -200,7 +200,7 @@ class SignRawTransactionsTest(DigiByteTestFramework):
         embedded_pubkey = eckey.get_pubkey().get_bytes().hex()
         p2sh_p2wsh_address = self.nodes[1].createmultisig(1, [embedded_pubkey], "p2sh-segwit")
         # send transaction to P2SH-P2WSH 1-of-1 multisig address
-        self.generate(self.nodes[0], COINBASE_MATURITY + 1)
+        self.generate(self.nodes[0], COINBASE_MATURITY_2 + 1)
         self.nodes[0].sendtoaddress(p2sh_p2wsh_address["address"], 49.999)
         self.generate(self.nodes[0], 1)
         # Get the UTXO info from scantxoutset

--- a/test/functional/wallet_importprunedfunds.py
+++ b/test/functional/wallet_importprunedfunds.py
@@ -5,7 +5,7 @@
 """Test the importprunedfunds and removeprunedfunds RPCs."""
 from decimal import Decimal
 
-from test_framework.blocktools import COINBASE_MATURITY
+from test_framework.blocktools import COINBASE_MATURITY_2
 from test_framework.address import key_to_p2wpkh
 from test_framework.key import ECKey
 from test_framework.test_framework import DigiByteTestFramework
@@ -25,7 +25,7 @@ class ImportPrunedFundsTest(DigiByteTestFramework):
 
     def run_test(self):
         self.log.info("Mining blocks...")
-        self.generate(self.nodes[0], COINBASE_MATURITY + 1)
+        self.generate(self.nodes[0], COINBASE_MATURITY_2 + 1)
 
         # address
         address1 = self.nodes[0].getnewaddress()
@@ -45,7 +45,7 @@ class ImportPrunedFundsTest(DigiByteTestFramework):
         self.sync_all()
 
         # Node 1 sync test
-        assert_equal(self.nodes[1].getblockcount(), COINBASE_MATURITY + 1)
+        assert_equal(self.nodes[1].getblockcount(), COINBASE_MATURITY_2 + 1)
 
         # Address Test - before import
         address_info = self.nodes[1].getaddressinfo(address1)


### PR DESCRIPTION
This PR fixes 1 of 2 functional tests for wallet_basic.py and 5 other functional tests. This test wallet_basic.py  is a doozy and after spending a few hours on it I figured I would share what I have done so far to see if anyone else has suggestions.

To test this:

Compile:

```
  ./autogen.sh
  ./configure
  make -j 8
```
Run Specific Functional Tests
```
test/functional/test_runner.py wallet_basic.py
test/functional/test_runner.py interface_digibyte_cli.py mining_basic.py mempool_unbroadcast.py rpc_signrawtransaction.py wallet_importprunedfunds.py 
```
![Screenshot 2024-03-08 at 9 37 22 AM](https://github.com/DigiByte-Core/digibyte/assets/13957390/b5010ec4-dc90-4d2d-9a51-81263b2995ca)

![Screenshot 2024-03-08 at 10 07 21 AM](https://github.com/DigiByte-Core/digibyte/assets/13957390/d35aae0f-6db3-4b2a-aa92-0a4fc78c5b6b)

![Screenshot 2024-03-08 at 11 32 13 AM](https://github.com/DigiByte-Core/digibyte/assets/13957390/b48d2b7b-1c40-4a40-8bc1-847a962d9e73)


![Screenshot 2024-03-08 at 8 52 16 AM](https://github.com/DigiByte-Core/digibyte/assets/13957390/a95b58cb-344c-46f4-9f71-f9e4a77d1f00)

I am still stuck on this error for 2nd wallet_basic.py  test:

![Screenshot 2024-03-08 at 8 52 09 AM](https://github.com/DigiByte-Core/digibyte/assets/13957390/533a4d5e-89e0-4628-8177-c8f742f32c5f)
