### PR TITLE
Update amount_tests.cpp

### DIFF
--- a/src/test/amount_tests.cpp
+++ b/src/test/amount_tests.cpp
@@ -85,7 +85,9 @@ BOOST_AUTO_TEST_CASE(GetFeeTest)
     BOOST_CHECK(CFeeRate(CAmount(26), 789) == CFeeRate(32));
     BOOST_CHECK(CFeeRate(CAmount(27), 789) == CFeeRate(34));
     // Maximum size in bytes, should not crash
-    CFeeRate(MAX_MONEY, std::numeric_limits<uint32_t>::max()).GetFeePerK();
+    size_t MAX_MONEY2;
+    MAX_MONEY2 = MAX_MONEY / 1000;
+    CFeeRate(MAX_MONEY2, std::numeric_limits<uint32_t>::max()).GetFeePerK();
 }
 
 BOOST_AUTO_TEST_CASE(BinaryOperatorTest)


### PR DESCRIPTION
This PR fixes amount_tests.cpp unit test on Linux. This test passes on mac but not linux because it appears the compilers handle it differently. Seems to be an int32 vs 64 issue. The test worked great for BTC, but not DGB with a larger `MAX_MONEY` integer. 

`make check` should now pass on all platforms.

You can read more about Unit Tests here:
https://github.com/DigiByte-Core/digibyte/blob/develop/src/test/README.md

To Compile & Run Unit Tests:
```
  ./autogen.sh
  ./configure
  make -j 8
  make check
```

Run Specific Unit Test Fixed
```
cd src/test
./test_digibyte --run_test=amount_tests
```

Thanks to @Jongjan88 for pointing this out & testing the fix! 