### PR TITLE
Fix 4 Functional Tests

### DIFF
--- a/test/functional/wallet_keypool.py
+++ b/test/functional/wallet_keypool.py
@@ -180,9 +180,9 @@ class KeyPoolTest(DigiByteTestFramework):
         assert_equal("psbt" in res, True)
 
         # create a transaction without change at the maximum fee rate, such that the output is still spendable:
-        res = w2.walletcreatefundedpsbt(inputs=[], outputs=[{destination: 0.00010000}], options={"subtractFeeFromOutputs": [0], "feeRate": 0.0008823})
+        res = w2.walletcreatefundedpsbt(inputs=[], outputs=[{destination: 0.00010000}], options={"subtractFeeFromOutputs": [0], "feeRate": 0.00001})
         assert_equal("psbt" in res, True)
-        assert_equal(res["fee"], Decimal("0.00009706"))
+        assert_equal(res["fee"], Decimal("0.00000110"))
 
         # creating a 10,000 sat transaction with a manual change address should be possible
         res = w2.walletcreatefundedpsbt(inputs=[], outputs=[{destination: 0.00010000}], options={"subtractFeeFromOutputs": [0], "feeRate": 0.00010, "changeAddress": addr.pop()})


### PR DESCRIPTION
This PR fixes 4 functional tests between rpc_rawtransaction.py  and wallet_keypool.py. 

To test this:

Compile:

```
  ./autogen.sh
  ./configure
  make -j 8
```
Run Specific Functional Tests
```
test/functional/test_runner.py rpc_rawtransaction.py wallet_keypool.py
```
![Screenshot 2024-03-21 at 1 13 27 PM](https://github.com/DigiByte-Core/digibyte/assets/13957390/e76458e0-af84-4bd8-973c-4d0400b69166)

![Screenshot 2024-03-21 at 1 28 12 PM](https://github.com/DigiByte-Core/digibyte/assets/13957390/ee2a227f-787c-48d4-b895-0254e24fc066)


