### PR TITLE
QT locale - change mentions of satoshi to digibit

### DIFF
--- a/src/qt/locale/digibyte_af.ts
+++ b/src/qt/locale/digibyte_af.ts
@@ -761,8 +761,8 @@
         <translation>This label turns red if any recipient receives an amount smaller than the current dust threshold.</translation>
     </message>
     <message>
-        <source>Can vary +/- %1 satoshi(s) per input.</source>
-        <translation>Can vary +/- %1 satoshi(s) per input.</translation>
+        <source>Can vary +/- %1 digibit(s) per input.</source>
+        <translation>Can vary +/- %1 digibit(s) per input.</translation>
     </message>
     <message>
         <source>(no label)</source>
@@ -2198,10 +2198,10 @@
     <message>
         <source>Specify a custom fee per kB (1,000 bytes) of the transaction's virtual size.
 
-Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis per kB" for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 satoshis.</source>
+Note:  Since the fee is calculated on a per-byte basis, a fee of "100 digibits per kB" for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 digibits.</source>
         <translation>Specify a custom fee per kB (1,000 bytes) of the transaction's virtual size.
 
-Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis per kB" for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 satoshis.</translation>
+Note:  Since the fee is calculated on a per-byte basis, a fee of "100 digibits per kB" for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 digibits.</translation>
     </message>
     <message>
         <source>per kilobyte</source>

--- a/src/qt/locale/digibyte_ar.ts
+++ b/src/qt/locale/digibyte_ar.ts
@@ -800,7 +800,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation>يتحول هذا الملصق إلى اللون الأحمر إذا تلقى أي مستلم كمية أصغر من عتبة الغبار الحالية.</translation>
     </message>
     <message>
-        <source>Can vary +/- %1 satoshi(s) per input.</source>
+        <source>Can vary +/- %1 digibit(s) per input.</source>
         <translation>يمكن أن يختلف +/- %1 من ساتوشي(s) لكل إدخال.</translation>
     </message>
     <message>

--- a/src/qt/locale/digibyte_bn.ts
+++ b/src/qt/locale/digibyte_bn.ts
@@ -761,8 +761,8 @@
         <translation>This label turns red if any recipient receives an amount smaller than the current dust threshold.</translation>
     </message>
     <message>
-        <source>Can vary +/- %1 satoshi(s) per input.</source>
-        <translation>Can vary +/- %1 satoshi(s) per input.</translation>
+        <source>Can vary +/- %1 digibit(s) per input.</source>
+        <translation>Can vary +/- %1 digibit(s) per input.</translation>
     </message>
     <message>
         <source>(no label)</source>
@@ -2198,10 +2198,10 @@
     <message>
         <source>Specify a custom fee per kB (1,000 bytes) of the transaction's virtual size.
 
-Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis per kB" for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 satoshis.</source>
+Note:  Since the fee is calculated on a per-byte basis, a fee of "100 digibits per kB" for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 digibits.</source>
         <translation>Specify a custom fee per kB (1,000 bytes) of the transaction's virtual size.
 
-Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis per kB" for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 satoshis.</translation>
+Note:  Since the fee is calculated on a per-byte basis, a fee of "100 digibits per kB" for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 digibits.</translation>
     </message>
     <message>
         <source>per kilobyte</source>

--- a/src/qt/locale/digibyte_ca.ts
+++ b/src/qt/locale/digibyte_ca.ts
@@ -807,8 +807,8 @@ Només és possible firmar amb adreces del tipus "legacy".</translation>
         <translation>Aquesta etiqueta es torna vermella si cap recipient rep un import inferior al llindar de polsim actual.</translation>
     </message>
     <message>
-        <source>Can vary +/- %1 satoshi(s) per input.</source>
-        <translation>Pot variar en +/- %1 satoshi(s) per entrada.</translation>
+        <source>Can vary +/- %1 digibit(s) per input.</source>
+        <translation>Pot variar en +/- %1 digibit(s) per entrada.</translation>
     </message>
     <message>
         <source>(no label)</source>
@@ -2285,10 +2285,10 @@ Això és ideal per a carteres de mode només lectura.</translation>
     <message>
         <source>Specify a custom fee per kB (1,000 bytes) of the transaction's virtual size.
 
-Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis per kB" for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 satoshis.</source>
+Note:  Since the fee is calculated on a per-byte basis, a fee of "100 digibits per kB" for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 digibits.</source>
         <translation>Especifiqui una comissió personalitzada per kB (1.000 bytes) de la mida virtual de la transacció.
 
-Nota: Com que la comissió es calcula en funció dels bytes, una comissió de "100 satoshis per cada kB" per una transacció de mida 500 bytes (la meitat de 1 kB) comportaria finalment una comissió de la transacció de només 50 satoshis.</translation>
+Nota: Com que la comissió es calcula en funció dels bytes, una comissió de "100 digibits per cada kB" per una transacció de mida 500 bytes (la meitat de 1 kB) comportaria finalment una comissió de la transacció de només 50 digibits.</translation>
     </message>
     <message>
         <source>per kilobyte</source>

--- a/src/qt/locale/digibyte_cs.ts
+++ b/src/qt/locale/digibyte_cs.ts
@@ -766,8 +766,8 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation>Popisek zčervená, pokud má některý příjemce obdržet částku menší, než je aktuální práh pro prach.</translation>
     </message>
     <message>
-        <source>Can vary +/- %1 satoshi(s) per input.</source>
-        <translation>Může se lišit o +/– %1 satoshi na každý vstup.</translation>
+        <source>Can vary +/- %1 digibit(s) per input.</source>
+        <translation>Může se lišit o +/– %1 digibit na každý vstup.</translation>
     </message>
     <message>
         <source>(no label)</source>
@@ -2211,10 +2211,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Specify a custom fee per kB (1,000 bytes) of the transaction's virtual size.
 
-Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis per kB" for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 satoshis.</source>
+Note:  Since the fee is calculated on a per-byte basis, a fee of "100 digibits per kB" for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 digibits.</source>
         <translation>Specifikujte vlastní poplatek za kB (1000 bajtů) virtuální velikosti transakce.
 
-Poznámka: Jelikož je poplatek počítaný za bajt, poplatek o hodnotě "100 satoshi za kB" a velikost transakce 500 bajtů (polovina z 1 kB) by stál jen 50 satoshi.</translation>
+Poznámka: Jelikož je poplatek počítaný za bajt, poplatek o hodnotě "100 digibit za kB" a velikost transakce 500 bajtů (polovina z 1 kB) by stál jen 50 digibit.</translation>
     </message>
     <message>
         <source>per kilobyte</source>

--- a/src/qt/locale/digibyte_da.ts
+++ b/src/qt/locale/digibyte_da.ts
@@ -761,8 +761,8 @@
         <translation>Denne mærkat bliver rød, hvis en eller flere modtagere modtager et beløb, der er mindre end den aktuelle støvgrænse.</translation>
     </message>
     <message>
-        <source>Can vary +/- %1 satoshi(s) per input.</source>
-        <translation>Kan variere med ±%1 satoshi per input.</translation>
+        <source>Can vary +/- %1 digibit(s) per input.</source>
+        <translation>Kan variere med ±%1 digibit per input.</translation>
     </message>
     <message>
         <source>(no label)</source>
@@ -2206,10 +2206,10 @@
     <message>
         <source>Specify a custom fee per kB (1,000 bytes) of the transaction's virtual size.
 
-Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis per kB" for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 satoshis.</source>
+Note:  Since the fee is calculated on a per-byte basis, a fee of "100 digibits per kB" for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 digibits.</source>
         <translation>Specificer et brugerdefineret gebyr per kB (1.000 bytes) af transaktionens virtuelle størrelse.
 
-Note: Siden gebyret er kalkuleret på en per-byte basis, et gebyr på "100 satoshis per kB" for en transkationsstørrelse på 500 bytes (halvdelen af 1kB) ville ultimativt udbytte et gebyr på kun 50 satoshis.</translation>
+Note: Siden gebyret er kalkuleret på en per-byte basis, et gebyr på "100 digibits per kB" for en transkationsstørrelse på 500 bytes (halvdelen af 1kB) ville ultimativt udbytte et gebyr på kun 50 digibits.</translation>
     </message>
     <message>
         <source>per kilobyte</source>

--- a/src/qt/locale/digibyte_de.ts
+++ b/src/qt/locale/digibyte_de.ts
@@ -807,8 +807,8 @@ Das Signieren ist nur mit Adressen vom Typ 'Legacy' möglich.</translation>
         <translation>Diese Bezeichnung wird rot, wenn irgendein Empfänger einen Betrag kleiner als die derzeitige "Staubgrenze" erhält.</translation>
     </message>
     <message>
-        <source>Can vary +/- %1 satoshi(s) per input.</source>
-        <translation>Kann pro Eingabe um +/- %1 Satoshi(s) abweichen.</translation>
+        <source>Can vary +/- %1 digibit(s) per input.</source>
+        <translation>Kann pro Eingabe um +/- %1 digibit(s) abweichen.</translation>
     </message>
     <message>
         <source>(no label)</source>
@@ -2400,10 +2400,10 @@ Das Signieren ist nur mit Adressen vom Typ 'Legacy' möglich.</translation>
     <message>
         <source>Specify a custom fee per kB (1,000 bytes) of the transaction's virtual size.
 
-Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis per kB" for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 satoshis.</source>
+Note:  Since the fee is calculated on a per-byte basis, a fee of "100 digibits per kB" for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 digibits.</source>
         <translation>Geben sie eine angepasste Gebühr pro kB (1.000 Byte) virtueller Größe der Transaktion an.
 
-Hinweis: Eine Gebühr von "100 Satoshis pro kB" bei einer Größe der Transaktion von 500 Byte (einem halben kB) würde eine Gebühr von 50 Satoshis ergeben, da die Gebühr pro Byte berechnet wird.</translation>
+Hinweis: Eine Gebühr von "100 digibits pro kB" bei einer Größe der Transaktion von 500 Byte (einem halben kB) würde eine Gebühr von 50 digibits ergeben, da die Gebühr pro Byte berechnet wird.</translation>
     </message>
     <message>
         <source>per kilobyte</source>

--- a/src/qt/locale/digibyte_en.ts
+++ b/src/qt/locale/digibyte_en.ts
@@ -3419,7 +3419,7 @@ For more information on using this console, type %6.
         <location line="+51"/>
         <source>Specify a custom fee per kB (1,000 bytes) of the transaction&apos;s virtual size.
 
-Note:  Since the fee is calculated on a per-byte basis, a fee rate of &quot;100 satoshis per kvB&quot; for a transaction size of 500 virtual bytes (half of 1 kvB) would ultimately yield a fee of only 50 satoshis.</source>
+Note:  Since the fee is calculated on a per-byte basis, a fee rate of &quot;100 digibits per kvB&quot; for a transaction size of 500 virtual bytes (half of 1 kvB) would ultimately yield a fee of only 50 digibits.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/qt/locale/digibyte_en.xlf
+++ b/src/qt/locale/digibyte_en.xlf
@@ -3579,7 +3579,7 @@ For more information on using this console, type %6.
       <trans-unit id="_msg648">
         <source xml:space="preserve">Specify a custom fee per kB (1,000 bytes) of the transaction&apos;s virtual size.
 
-Note:  Since the fee is calculated on a per-byte basis, a fee rate of &quot;100 satoshis per kvB&quot; for a transaction size of 500 virtual bytes (half of 1 kvB) would ultimately yield a fee of only 50 satoshis.</source>
+Note:  Since the fee is calculated on a per-byte basis, a fee rate of &quot;100 digibits per kvB&quot; for a transaction size of 500 virtual bytes (half of 1 kvB) would ultimately yield a fee of only 50 digibits.</source>
         <target xml:space="preserve"></target>
         <context-group purpose="location"><context context-type="linenumber">851</context></context-group>
       </trans-unit>

--- a/src/qt/locale/digibyte_en_GB.ts
+++ b/src/qt/locale/digibyte_en_GB.ts
@@ -807,8 +807,8 @@ Signing is only possible with addresses of the type 'legacy'.</translation>
         <translation>This label turns red if any recipient receives an amount smaller than the current dust threshold.</translation>
     </message>
     <message>
-        <source>Can vary +/- %1 satoshi(s) per input.</source>
-        <translation>Can vary +/- %1 satoshi(s) per input.</translation>
+        <source>Can vary +/- %1 digibit(s) per input.</source>
+        <translation>Can vary +/- %1 digibit(s) per input.</translation>
     </message>
     <message>
         <source>(no label)</source>
@@ -2404,10 +2404,10 @@ Signing is only possible with addresses of the type 'legacy'.</translation>
     <message>
         <source>Specify a custom fee per kB (1,000 bytes) of the transaction's virtual size.
 
-Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis per kB" for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 satoshis.</source>
+Note:  Since the fee is calculated on a per-byte basis, a fee of "100 digibits per kB" for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 digibits.</source>
         <translation>Specify a custom fee per kB (1,000 bytes) of the transaction's virtual size.
 
-Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis per kB" for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 satoshis.</translation>
+Note:  Since the fee is calculated on a per-byte basis, a fee of "100 digibits per kB" for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 digibits.</translation>
     </message>
     <message>
         <source>per kilobyte</source>

--- a/src/qt/locale/digibyte_es.ts
+++ b/src/qt/locale/digibyte_es.ts
@@ -807,8 +807,8 @@ Firmar solo es posible con correos del tipo Legacy.</translation>
         <translation>Esta etiqueta se vuelve roja si algún receptor recibe una cantidad inferior al umbral actual establecido para el polvo.</translation>
     </message>
     <message>
-        <source>Can vary +/- %1 satoshi(s) per input.</source>
-        <translation>Puede variar +/- %1 satoshi(s) por entrada.</translation>
+        <source>Can vary +/- %1 digibit(s) per input.</source>
+        <translation>Puede variar +/- %1 digibit(s) por entrada.</translation>
     </message>
     <message>
         <source>(no label)</source>
@@ -2400,10 +2400,10 @@ Firmar solo es posible con correos del tipo Legacy.</translation>
     <message>
         <source>Specify a custom fee per kB (1,000 bytes) of the transaction's virtual size.
 
-Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis per kB" for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 satoshis.</source>
+Note:  Since the fee is calculated on a per-byte basis, a fee of "100 digibits per kB" for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 digibits.</source>
         <translation>Especifique una comisión personalizada por kB (1,000 bytes) del tamaño virtual de la transacción.
 
-Nota: Dado que la comisión se calcula por byte, una comisión de "100 satoshis por kB" para un tamaño de transacción de 500 bytes (la mitad de 1 kB) finalmente generará una comisión de solo 50 satoshis.</translation>
+Nota: Dado que la comisión se calcula por byte, una comisión de "100 digibits por kB" para un tamaño de transacción de 500 bytes (la mitad de 1 kB) finalmente generará una comisión de solo 50 digibits.</translation>
     </message>
     <message>
         <source>per kilobyte</source>

--- a/src/qt/locale/digibyte_fi.ts
+++ b/src/qt/locale/digibyte_fi.ts
@@ -815,8 +815,8 @@ Allekirjoitus on mahdollista vain 'legacy'-tyyppisillä osoitteilla.</translatio
         <translation>Tämä nimike muuttuu punaiseksi, jos jokin vastaanottajista on saamassa tämänhetkistä tomun rajaa pienemmän summan.</translation>
     </message>
     <message>
-        <source>Can vary +/- %1 satoshi(s) per input.</source>
-        <translation>Saattaa vaihdella +/- %1 satoshia per syöte.</translation>
+        <source>Can vary +/- %1 digibit(s) per input.</source>
+        <translation>Saattaa vaihdella +/- %1 digibits per syöte.</translation>
     </message>
     <message>
         <source>(no label)</source>
@@ -2416,10 +2416,10 @@ Allekirjoitus on mahdollista vain 'legacy'-tyyppisillä osoitteilla.</translatio
     <message>
         <source>Specify a custom fee per kB (1,000 bytes) of the transaction's virtual size.
 
-Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis per kB" for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 satoshis.</source>
+Note:  Since the fee is calculated on a per-byte basis, a fee of "100 digibits per kB" for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 digibits.</source>
         <translation>Määrittele siirtotapahtuman näennäiskooksi siirtomaksu kilotavua (1,000 tavua) kohti.
 
-Huom: Koska siirtomaksu lasketaan tavujen mukaan, niin määrittelemällä 500 tavun (puoli kt) siirrolle "100 sat / kt", johtaa tämä lopulta vain 50 satoshin maksuun.</translation>
+Huom: Koska siirtomaksu lasketaan tavujen mukaan, niin määrittelemällä 500 tavun (puoli kt) siirrolle "100 sat / kt", johtaa tämä lopulta vain 50 digibits maksuun.</translation>
     </message>
     <message>
         <source>per kilobyte</source>

--- a/src/qt/locale/digibyte_fil.ts
+++ b/src/qt/locale/digibyte_fil.ts
@@ -741,8 +741,8 @@
         <translation>Ang label na ito ay magiging pula kung ang sinumang tatanggap ay tumanggap ng halagang mas mababa sa kasalukuyang dust threshold.</translation>
     </message>
     <message>
-        <source>Can vary +/- %1 satoshi(s) per input.</source>
-        <translation>Maaaring magbago ng +/- %1 satoshi(s) kada input.</translation>
+        <source>Can vary +/- %1 digibit(s) per input.</source>
+        <translation>Maaaring magbago ng +/- %1 digibit(s) kada input.</translation>
     </message>
     <message>
         <source>(no label)</source>
@@ -2119,10 +2119,10 @@
     <message>
         <source>Specify a custom fee per kB (1,000 bytes) of the transaction's virtual size.
 
-Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis per kB" for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 satoshis.</source>
+Note:  Since the fee is calculated on a per-byte basis, a fee of "100 digibits per kB" for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 digibits.</source>
         <translation>Tumukoy ng custom fee kada kB (1,000 bytes) ng virtual size ng transaksyon.
 
-Tandaan: Dahil ang bayad  ay kinakalkula sa bawat-byte na batayan, ang bayad ng "100 satoshis kada kB" para sa transaksyon na 500 bytes (kalahati ng 1 kB) ay magkakaroon ng bayad na 50 lamang na satoshi.</translation>
+Tandaan: Dahil ang bayad  ay kinakalkula sa bawat-byte na batayan, ang bayad ng "100 digibits kada kB" para sa transaksyon na 500 bytes (kalahati ng 1 kB) ay magkakaroon ng bayad na 50 lamang na digibits.</translation>
     </message>
     <message>
         <source>per kilobyte</source>

--- a/src/qt/locale/digibyte_fr.ts
+++ b/src/qt/locale/digibyte_fr.ts
@@ -2404,10 +2404,10 @@ Il n’est possible de signer qu’avec les adresses de type « legacy ».</tr
     <message>
         <source>Specify a custom fee per kB (1,000 bytes) of the transaction's virtual size.
 
-Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis per kB" for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 satoshis.</source>
+Note:  Since the fee is calculated on a per-byte basis, a fee of "100 digibits per kB" for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 digibits.</source>
         <translation>Déterminer des frais personnalisés par Ko (1 000 octets) de la taille virtuelle de la transaction.
 
-Note : Les frais étant calculés par octet, des frais de « 100 satoshis par Ko » pour une transaction d’une taille de 500 octets (la moitié de 1 Ko) donneront des frais de seulement 50 satoshis.</translation>
+Note : Les frais étant calculés par octet, des frais de « 100 digibits par Ko » pour une transaction d’une taille de 500 octets (la moitié de 1 Ko) donneront des frais de seulement 50 digibits.</translation>
     </message>
     <message>
         <source>per kilobyte</source>

--- a/src/qt/locale/digibyte_gl_ES.ts
+++ b/src/qt/locale/digibyte_gl_ES.ts
@@ -761,8 +761,8 @@
         <translation>Esta etiqueta tórnase vermella se algún receptor recibe unha cantidade máis pequena que o actual límite de po.</translation>
     </message>
     <message>
-        <source>Can vary +/- %1 satoshi(s) per input.</source>
-        <translation>Pode variar +/- %1 satoshi(s) por entrada.</translation>
+        <source>Can vary +/- %1 digibit(s) per input.</source>
+        <translation>Pode variar +/- %1 digibit(s) por entrada.</translation>
     </message>
     <message>
         <source>(no label)</source>
@@ -2198,10 +2198,10 @@
     <message>
         <source>Specify a custom fee per kB (1,000 bytes) of the transaction's virtual size.
 
-Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis per kB" for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 satoshis.</source>
+Note:  Since the fee is calculated on a per-byte basis, a fee of "100 digibits per kB" for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 digibits.</source>
         <translation>Specify a custom fee per kB (1,000 bytes) of the transaction's virtual size.
 
-Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis per kB" for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 satoshis.</translation>
+Note:  Since the fee is calculated on a per-byte basis, a fee of "100 digibits per kB" for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 digibits.</translation>
     </message>
     <message>
         <source>per kilobyte</source>

--- a/src/qt/locale/digibyte_he.ts
+++ b/src/qt/locale/digibyte_he.ts
@@ -805,7 +805,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation>תווית זו הופכת לאדומה אם מישהו מהנמענים מקבל סכום נמוך יותר מסף האבק הנוכחי.</translation>
     </message>
     <message>
-        <source>Can vary +/- %1 satoshi(s) per input.</source>
+        <source>Can vary +/- %1 digibit(s) per input.</source>
         <translation>יכול להשתנות במגמה של +/- %1 סנטושי לקלט.</translation>
     </message>
     <message>
@@ -2394,7 +2394,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Specify a custom fee per kB (1,000 bytes) of the transaction's virtual size.
 
-Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis per kB" for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 satoshis.</source>
+Note:  Since the fee is calculated on a per-byte basis, a fee of "100 digibits per kB" for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 digibits.</source>
         <translation>ציינו עמלה מותאמת אישית פר קילובייט (1000 בתים) של הגודל הוירטואלי של העסקה.
 
 לתשומת לבכם: מאחר והעמלה מחושבת על בסיס פר-בית, עמלה של "100 סטושי פר קילובייט" עבור עסקה בגודל 500 בתים (חצי קילובייט) תפיק בסופו של דבר עמלה של 50 סטושי בלבד.</translation>

--- a/src/qt/locale/digibyte_hu.ts
+++ b/src/qt/locale/digibyte_hu.ts
@@ -805,8 +805,8 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation>Ez a címke pirosra változik, ha bármely fogadóhoz, a porszem határértéknél kevesebb összeg érkezik.</translation>
     </message>
     <message>
-        <source>Can vary +/- %1 satoshi(s) per input.</source>
-        <translation>Megadott értékenként  +/- %1 satoshi-val változhat.</translation>
+        <source>Can vary +/- %1 digibit(s) per input.</source>
+        <translation>Megadott értékenként  +/- %1 digibit-val változhat.</translation>
     </message>
     <message>
         <source>(no label)</source>
@@ -2398,10 +2398,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Specify a custom fee per kB (1,000 bytes) of the transaction's virtual size.
 
-Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis per kB" for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 satoshis.</source>
+Note:  Since the fee is calculated on a per-byte basis, a fee of "100 digibits per kB" for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 digibits.</source>
         <translation>Add meg a választott tranzakciós díjat kB (1000 bájt) -onként a tranzakció virtuális méretére számolva.
 
-Figyelem: Mivel bájtonként lesz a dj kiszámolva ezért a "100 satoshi per kB" egy 500 bájtos (fél kB) tranzakciónál  ténylegesen 50 satoshi lesz.</translation>
+Figyelem: Mivel bájtonként lesz a dj kiszámolva ezért a "100 digibit per kB" egy 500 bájtos (fél kB) tranzakciónál  ténylegesen 50 digibit lesz.</translation>
     </message>
     <message>
         <source>per kilobyte</source>

--- a/src/qt/locale/digibyte_hu_HU.ts
+++ b/src/qt/locale/digibyte_hu_HU.ts
@@ -691,8 +691,8 @@
         <translation>Ez a címke pirosra változik, ha valamelyik fogadó fél kisebb összeget kap, mint a jelenlegi porszem határérték.</translation>
     </message>
     <message>
-        <source>Can vary +/- %1 satoshi(s) per input.</source>
-        <translation>Változó +/- %1 satoshi(k) megadott értékenként.</translation>
+        <source>Can vary +/- %1 digibit(s) per input.</source>
+        <translation>Változó +/- %1 digibit(k) megadott értékenként.</translation>
     </message>
     <message>
         <source>(no label)</source>

--- a/src/qt/locale/digibyte_id.ts
+++ b/src/qt/locale/digibyte_id.ts
@@ -761,8 +761,8 @@
         <translation>Label ini akan menjadi merah apabila penerima menerima jumlah yang lebih kecil daripada ambang habuk semasa.</translation>
     </message>
     <message>
-        <source>Can vary +/- %1 satoshi(s) per input.</source>
-        <translation>Dapat bervariasi +/- %1 satoshi per input.</translation>
+        <source>Can vary +/- %1 digibit(s) per input.</source>
+        <translation>Dapat bervariasi +/- %1 digibit per input.</translation>
     </message>
     <message>
         <source>(no label)</source>
@@ -2196,10 +2196,10 @@
     <message>
         <source>Specify a custom fee per kB (1,000 bytes) of the transaction's virtual size.
 
-Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis per kB" for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 satoshis.</source>
+Note:  Since the fee is calculated on a per-byte basis, a fee of "100 digibits per kB" for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 digibits.</source>
         <translation>Tentukan biaya khusus per kB (1.000 byte) dari ukuran transaksi maya.
 
-Catatan: Karena biaya dihitung berdasarkan per byte, biaya "100 satoshi per kB" untuk ukuran transaksi 500 byte (setengah dari 1 kB) pada akhirnya akan menghasilkan biaya hanya 50 satoshi.</translation>
+Catatan: Karena biaya dihitung berdasarkan per byte, biaya "100 digibit per kB" untuk ukuran transaksi 500 byte (setengah dari 1 kB) pada akhirnya akan menghasilkan biaya hanya 50 digibit.</translation>
     </message>
     <message>
         <source>per kilobyte</source>

--- a/src/qt/locale/digibyte_it.ts
+++ b/src/qt/locale/digibyte_it.ts
@@ -807,8 +807,8 @@ E' possibile firmare solo con indirizzi di tipo "legacy".</translation>
         <translation>Questa etichetta diventerà rossa se uno qualsiasi dei destinatari riceverà un importo inferiore alla corrente soglia minima per la movimentazione della valuta.</translation>
     </message>
     <message>
-        <source>Can vary +/- %1 satoshi(s) per input.</source>
-        <translation>Può variare di +/- %1 satoshi per input.</translation>
+        <source>Can vary +/- %1 digibit(s) per input.</source>
+        <translation>Può variare di +/- %1 digibit per input.</translation>
     </message>
     <message>
         <source>(no label)</source>
@@ -2405,10 +2405,10 @@ Per specificare più URL separarli con una barra verticale "|".</translation>
     <message>
         <source>Specify a custom fee per kB (1,000 bytes) of the transaction's virtual size.
 
-Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis per kB" for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 satoshis.</source>
+Note:  Since the fee is calculated on a per-byte basis, a fee of "100 digibits per kB" for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 digibits.</source>
         <translation>Specifica una tariffa personalizzata per kB (1.000 byte) della dimensione virtuale della transazione
 
-Nota: poiché la commissione è calcolata su base per byte, una commissione di "100 satoshi per kB" per una dimensione di transazione di 500 byte (metà di 1 kB) alla fine produrrà una commissione di soli 50 satoshi.</translation>
+Nota: poiché la commissione è calcolata su base per byte, una commissione di "100 digibit per kB" per una dimensione di transazione di 500 byte (metà di 1 kB) alla fine produrrà una commissione di soli 50 digibit.</translation>
     </message>
     <message>
         <source>per kilobyte</source>

--- a/src/qt/locale/digibyte_ja.ts
+++ b/src/qt/locale/digibyte_ja.ts
@@ -782,8 +782,8 @@
         <translation>受取額が現在のダスト閾値を下回るアドレスがひとつでもあると、このラベルが赤くなります。</translation>
     </message>
     <message>
-        <source>Can vary +/- %1 satoshi(s) per input.</source>
-        <translation>インプット毎に %1 satoshi 前後変動する場合があります。</translation>
+        <source>Can vary +/- %1 digibit(s) per input.</source>
+        <translation>インプット毎に %1 digibit 前後変動する場合があります。</translation>
     </message>
     <message>
         <source>(no label)</source>
@@ -2255,10 +2255,10 @@
     <message>
         <source>Specify a custom fee per kB (1,000 bytes) of the transaction's virtual size.
 
-Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis per kB" for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 satoshis.</source>
+Note:  Since the fee is calculated on a per-byte basis, a fee of "100 digibits per kB" for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 digibits.</source>
         <translation>トランザクションの仮想サイズの1 kB(1,000 バイト)あたりのカスタム手数料を指定する。
 
-注: 手数料はバイト単位で計算されるので、500 バイト(1 kBの半分)のトランザクションサイズに対する「1 kBあたり 100 satoshi」の手数料は、最終的にはわずか 50 satoshi となります。</translation>
+注: 手数料はバイト単位で計算されるので、500 バイト(1 kBの半分)のトランザクションサイズに対する「1 kBあたり 100 digibit」の手数料は、最終的にはわずか 50 digibit となります。</translation>
     </message>
     <message>
         <source>per kilobyte</source>

--- a/src/qt/locale/digibyte_ja_JP.ts
+++ b/src/qt/locale/digibyte_ja_JP.ts
@@ -679,8 +679,8 @@
         <translation>受信したレシピが現在のダスト閾値よりも残高が少ない場合、ラベルは赤になります。</translation>
     </message>
     <message>
-        <source>Can vary +/- %1 satoshi(s) per input.</source>
-        <translation>入力ごとにsatoshiの+/- %1に変更できます。</translation>
+        <source>Can vary +/- %1 digibit(s) per input.</source>
+        <translation>入力ごとにdigibitの+/- %1に変更できます。</translation>
     </message>
     <message>
         <source>(no label)</source>
@@ -1965,8 +1965,8 @@
         <translation>キロバイトごと</translation>
     </message>
     <message>
-        <source>If the custom fee is set to 1000 satoshis and the transaction is only 250 bytes, then "per kilobyte" only pays 250 satoshis in fee, while "total at least" pays 1000 satoshis. For transactions bigger than a kilobyte both pay by kilobyte.</source>
-        <translation>カスタム料金が1000 satoshiで処理が250バイトのみの場合、料金はキロバイトあたりは250 satoshiのみとなり、最新の合計は1000 satoshiまで支払います。処理が1キロバイトよりも大きい場合、キロバイトごとに支払いが行われます。</translation>
+        <source>If the custom fee is set to 1000 digibits and the transaction is only 250 bytes, then "per kilobyte" only pays 250 digibits in fee, while "total at least" pays 1000 digibits. For transactions bigger than a kilobyte both pay by kilobyte.</source>
+        <translation>カスタム料金が1000 digibitで処理が250バイトのみの場合、料金はキロバイトあたりは250 digibitのみとなり、最新の合計は1000 digibitまで支払います。処理が1キロバイトよりも大きい場合、キロバイトごとに支払いが行われます。</translation>
     </message>
     <message>
         <source>Hide</source>

--- a/src/qt/locale/digibyte_ko.ts
+++ b/src/qt/locale/digibyte_ko.ts
@@ -761,7 +761,7 @@
         <translation>수령인이 현재 더스트 임계값보다 작은 양을 수신하면 이 라벨이 빨간색으로 변합니다.</translation>
     </message>
     <message>
-        <source>Can vary +/- %1 satoshi(s) per input.</source>
+        <source>Can vary +/- %1 digibit(s) per input.</source>
         <translation>입력마다 +/- %1 사토시가 변할 수 있습니다.</translation>
     </message>
     <message>
@@ -2162,10 +2162,10 @@
     <message>
         <source>Specify a custom fee per kB (1,000 bytes) of the transaction's virtual size.
 
-Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis per kB" for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 satoshis.</source>
+Note:  Since the fee is calculated on a per-byte basis, a fee of "100 digibits per kB" for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 digibits.</source>
         <translation>거래 가상 크기의 kB (1,000 바이트)당 수수료을 지정하십시오.
 
-참고 : 수수료는 바이트 단위로 계산되므로 거래 크기가 500 바이트 (1kB의 절반)일때에 수수료가 "100 satoshis / kB"이면 궁극적으로 50사토시의 수수료만 발생합니다.</translation>
+참고 : 수수료는 바이트 단위로 계산되므로 거래 크기가 500 바이트 (1kB의 절반)일때에 수수료가 "100 digibits / kB"이면 궁극적으로 50사토시의 수수료만 발생합니다.</translation>
     </message>
     <message>
         <source>per kilobyte</source>

--- a/src/qt/locale/digibyte_ko_KR.ts
+++ b/src/qt/locale/digibyte_ko_KR.ts
@@ -761,7 +761,7 @@
         <translation>수령인이 현재 더스트 임계값보다 작은 양을 수신하면 이 라벨이 빨간색으로 변합니다.</translation>
     </message>
     <message>
-        <source>Can vary +/- %1 satoshi(s) per input.</source>
+        <source>Can vary +/- %1 digibit(s) per input.</source>
         <translation>입력마다 +/- %1 사토시가 변할 수 있습니다.</translation>
     </message>
     <message>
@@ -2162,10 +2162,10 @@
     <message>
         <source>Specify a custom fee per kB (1,000 bytes) of the transaction's virtual size.
 
-Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis per kB" for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 satoshis.</source>
+Note:  Since the fee is calculated on a per-byte basis, a fee of "100 digibits per kB" for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 digibits.</source>
         <translation>거래 가상 크기의 kB (1,000 바이트)당 수수료을 지정하십시오.
 
-참고 : 수수료는 바이트 단위로 계산되므로 거래 크기가 500 바이트 (1kB의 절반)일때에 수수료가 "100 satoshis / kB"이면 궁극적으로 50사토시의 수수료만 발생합니다.</translation>
+참고 : 수수료는 바이트 단위로 계산되므로 거래 크기가 500 바이트 (1kB의 절반)일때에 수수료가 "100 digibits / kB"이면 궁극적으로 50사토시의 수수료만 발생합니다.</translation>
     </message>
     <message>
         <source>per kilobyte</source>

--- a/src/qt/locale/digibyte_ms.ts
+++ b/src/qt/locale/digibyte_ms.ts
@@ -759,8 +759,8 @@ Alihkan fail data ke dalam tab semasa</translation>
         <translation>This label turns red if any recipient receives an amount smaller than the current dust threshold.</translation>
     </message>
     <message>
-        <source>Can vary +/- %1 satoshi(s) per input.</source>
-        <translation>Can vary +/- %1 satoshi(s) per input.</translation>
+        <source>Can vary +/- %1 digibit(s) per input.</source>
+        <translation>Can vary +/- %1 digibit(s) per input.</translation>
     </message>
     <message>
         <source>(no label)</source>
@@ -2161,10 +2161,10 @@ Alihkan fail data ke dalam tab semasa</translation>
     <message>
         <source>Specify a custom fee per kB (1,000 bytes) of the transaction's virtual size.
 
-Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis per kB" for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 satoshis.</source>
+Note:  Since the fee is calculated on a per-byte basis, a fee of "100 digibits per kB" for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 digibits.</source>
         <translation>Specify a custom fee per kB (1,000 bytes) of the transaction's virtual size.
 
-Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis per kB" for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 satoshis.</translation>
+Note:  Since the fee is calculated on a per-byte basis, a fee of "100 digibits per kB" for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 digibits.</translation>
     </message>
     <message>
         <source>per kilobyte</source>

--- a/src/qt/locale/digibyte_nb.ts
+++ b/src/qt/locale/digibyte_nb.ts
@@ -761,8 +761,8 @@
         <translation>Denne merkelappen blir rød hvis en mottaker får mindre enn gjeldende støvterskel.</translation>
     </message>
     <message>
-        <source>Can vary +/- %1 satoshi(s) per input.</source>
-        <translation>Kan variere +/- %1 satoshi(er) per input.</translation>
+        <source>Can vary +/- %1 digibit(s) per input.</source>
+        <translation>Kan variere +/- %1 digibit(er) per input.</translation>
     </message>
     <message>
         <source>(no label)</source>
@@ -2190,10 +2190,10 @@
     <message>
         <source>Specify a custom fee per kB (1,000 bytes) of the transaction's virtual size.
 
-Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis per kB" for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 satoshis.</source>
+Note:  Since the fee is calculated on a per-byte basis, a fee of "100 digibits per kB" for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 digibits.</source>
         <translation>Spesifiser en tilpasset avgift per kB (1000 byte) av transaksjonens virtuelle størrelse.
 
-Merk: Siden avgiften er beregnet per byte-basis, vil et gebyr på "100 satoshis per kB" for en transaksjonsstørrelse på 500 byte (halvparten av 1 kB) til slutt gi et gebyr på bare 50 satoshis.</translation>
+Merk: Siden avgiften er beregnet per byte-basis, vil et gebyr på "100 digibits per kB" for en transaksjonsstørrelse på 500 byte (halvparten av 1 kB) til slutt gi et gebyr på bare 50 digibits.</translation>
     </message>
     <message>
         <source>per kilobyte</source>

--- a/src/qt/locale/digibyte_nl.ts
+++ b/src/qt/locale/digibyte_nl.ts
@@ -807,8 +807,8 @@ Ondertekenen is alleen mogelijk met adressen van het type 'legacy'.</translation
         <translation>Dit label wordt rood, als een ontvanger een bedrag van minder dan de huidige dust-drempel gekregen heeft.</translation>
     </message>
     <message>
-        <source>Can vary +/- %1 satoshi(s) per input.</source>
-        <translation>Kan per input +/- %1 satoshi(s)  variëren.</translation>
+        <source>Can vary +/- %1 digibit(s) per input.</source>
+        <translation>Kan per input +/- %1 digibit(s)  variëren.</translation>
     </message>
     <message>
         <source>(no label)</source>
@@ -2305,10 +2305,10 @@ Dit is ideaal voor alleen-lezen portommonees.</translation>
     <message>
         <source>Specify a custom fee per kB (1,000 bytes) of the transaction's virtual size.
 
-Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis per kB" for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 satoshis.</source>
+Note:  Since the fee is calculated on a per-byte basis, a fee of "100 digibits per kB" for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 digibits.</source>
         <translation>Specificeer handmatig een vergoeding per kB (1,000 bytes) voor de virtuele grootte van de transactie.
 
-Notitie: Omdat de vergoeding per byte wordt gerekend, zal een vergoeding van "100 satoshis per kB" voor een transactie ten grootte van 500 bytes (de helft van 1 kB) uiteindelijk een vergoeding van maar liefst 50 satoshis betekenen.</translation>
+Notitie: Omdat de vergoeding per byte wordt gerekend, zal een vergoeding van "100 digibits per kB" voor een transactie ten grootte van 500 bytes (de helft van 1 kB) uiteindelijk een vergoeding van maar liefst 50 digibits betekenen.</translation>
     </message>
     <message>
         <source>per kilobyte</source>

--- a/src/qt/locale/digibyte_pl.ts
+++ b/src/qt/locale/digibyte_pl.ts
@@ -795,8 +795,8 @@ Podpisywanie jest możliwe tylko z adresami typu „legacy”.</translation>
         <translation>Ta etykieta staje się czerwona jeżeli którykolwiek odbiorca otrzymuje kwotę mniejszą niż obecny próg pyłu.</translation>
     </message>
     <message>
-        <source>Can vary +/- %1 satoshi(s) per input.</source>
-        <translation>Waha się +/- %1 satoshi na wejście.</translation>
+        <source>Can vary +/- %1 digibit(s) per input.</source>
+        <translation>Waha się +/- %1 digibit na wejście.</translation>
     </message>
     <message>
         <source>(no label)</source>
@@ -2313,10 +2313,10 @@ Korzystanie z opłaty domyślnej może skutkować wysłaniem transakcji, która 
     <message>
         <source>Specify a custom fee per kB (1,000 bytes) of the transaction's virtual size.
 
-Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis per kB" for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 satoshis.</source>
+Note:  Since the fee is calculated on a per-byte basis, a fee of "100 digibits per kB" for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 digibits.</source>
         <translation>Określ niestandardową opłatę za kB (1000 bajtów) wirtualnego rozmiaru transakcji.
 
-Uwaga: Ponieważ opłata jest naliczana za każdy bajt, opłata "100 satoshi za kB" w przypadku transakcji o wielkości 500 bajtów (połowa 1 kB) ostatecznie da opłatę w wysokości tylko 50 satoshi.</translation>
+Uwaga: Ponieważ opłata jest naliczana za każdy bajt, opłata "100 digibits za kB" w przypadku transakcji o wielkości 500 bajtów (połowa 1 kB) ostatecznie da opłatę w wysokości tylko 50 digibits.</translation>
     </message>
     <message>
         <source>per kilobyte</source>

--- a/src/qt/locale/digibyte_pt.ts
+++ b/src/qt/locale/digibyte_pt.ts
@@ -785,8 +785,8 @@
         <translation>Esta etiqueta fica vermelha se qualquer destinatário recebe um valor menor que o limite de dinheiro.</translation>
     </message>
     <message>
-        <source>Can vary +/- %1 satoshi(s) per input.</source>
-        <translation>Pode variar +/- %1 satoshi(s) por input.</translation>
+        <source>Can vary +/- %1 digibit(s) per input.</source>
+        <translation>Pode variar +/- %1 digibit(s) por input.</translation>
     </message>
     <message>
         <source>(no label)</source>
@@ -2360,10 +2360,10 @@ ID transação: %1</translation>
     <message>
         <source>Specify a custom fee per kB (1,000 bytes) of the transaction's virtual size.
 
-Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis per kB" for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 satoshis.</source>
+Note:  Since the fee is calculated on a per-byte basis, a fee of "100 digibits per kB" for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 digibits.</source>
         <translation>Especifique uma taxa personalizada por kB (1.000 bytes) do tamanho virtual da transação.
 
-Nota: como a taxa é calculada por byte, uma taxa de "100 satoshis por kB" por uma transação de 500 bytes (metade de 1 kB) teria uma taxa final de apenas 50 satoshis.</translation>
+Nota: como a taxa é calculada por byte, uma taxa de "100 digibits por kB" por uma transação de 500 bytes (metade de 1 kB) teria uma taxa final de apenas 50 digibits.</translation>
     </message>
     <message>
         <source>per kilobyte</source>

--- a/src/qt/locale/digibyte_pt_BR.ts
+++ b/src/qt/locale/digibyte_pt_BR.ts
@@ -807,8 +807,8 @@ Somente é possível assinar com endereços do tipo 'legado'.</translation>
         <translation>Este texto fica vermelho se qualquer destinatário receber uma quantidade menor que o limite atual para poeira.</translation>
     </message>
     <message>
-        <source>Can vary +/- %1 satoshi(s) per input.</source>
-        <translation>Pode variar +/- %1 satoshi(s) por entrada</translation>
+        <source>Can vary +/- %1 digibit(s) per input.</source>
+        <translation>Pode variar +/- %1 digibit(s) por entrada</translation>
     </message>
     <message>
         <source>(no label)</source>
@@ -2404,10 +2404,10 @@ Somente é possível assinar com endereços do tipo 'legado'.</translation>
     <message>
         <source>Specify a custom fee per kB (1,000 bytes) of the transaction's virtual size.
 
-Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis per kB" for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 satoshis.</source>
+Note:  Since the fee is calculated on a per-byte basis, a fee of "100 digibits per kB" for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 digibits.</source>
         <translation>Especifique uma taxa personalizada por kB (1.000 bytes) do tamanho virtual da transação.
 
-Nota:  Como a taxa é calculada por byte, uma taxa de "100 satoshis por kB" por uma transação de 500 bytes (metade de 1 kB) teria uma taxa final de apenas 50 satoshis.</translation>
+Nota:  Como a taxa é calculada por byte, uma taxa de "100 digibits por kB" por uma transação de 500 bytes (metade de 1 kB) teria uma taxa final de apenas 50 digibits.</translation>
     </message>
     <message>
         <source>per kilobyte</source>

--- a/src/qt/locale/digibyte_pt_PT.ts
+++ b/src/qt/locale/digibyte_pt_PT.ts
@@ -785,8 +785,8 @@
         <translation>Esta etiqueta fica vermelha se qualquer destinatário recebe um valor menor que o limite de dinheiro.</translation>
     </message>
     <message>
-        <source>Can vary +/- %1 satoshi(s) per input.</source>
-        <translation>Pode variar +/- %1 satoshi(s) por input.</translation>
+        <source>Can vary +/- %1 digibit(s) per input.</source>
+        <translation>Pode variar +/- %1 digibit(s) por input.</translation>
     </message>
     <message>
         <source>(no label)</source>
@@ -2360,10 +2360,10 @@ ID transação: %1</translation>
     <message>
         <source>Specify a custom fee per kB (1,000 bytes) of the transaction's virtual size.
 
-Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis per kB" for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 satoshis.</source>
+Note:  Since the fee is calculated on a per-byte basis, a fee of "100 digibits per kB" for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 digibits.</source>
         <translation>Especifique uma taxa personalizada por kB (1.000 bytes) do tamanho virtual da transação.
 
-Nota: como a taxa é calculada por byte, uma taxa de "100 satoshis por kB" por uma transação de 500 bytes (metade de 1 kB) teria uma taxa final de apenas 50 satoshis.</translation>
+Nota: como a taxa é calculada por byte, uma taxa de "100 digibits por kB" por uma transação de 500 bytes (metade de 1 kB) teria uma taxa final de apenas 50 digibits.</translation>
     </message>
     <message>
         <source>per kilobyte</source>

--- a/src/qt/locale/digibyte_ro.ts
+++ b/src/qt/locale/digibyte_ro.ts
@@ -745,8 +745,8 @@
         <translation>Această etichetă devine roşie, dacă orice beneficiar primeşte o sumă mai mică decât pragul curent pentru praf.</translation>
     </message>
     <message>
-        <source>Can vary +/- %1 satoshi(s) per input.</source>
-        <translation>Poate varia +/- %1 satoshi pentru fiecare intrare.</translation>
+        <source>Can vary +/- %1 digibit(s) per input.</source>
+        <translation>Poate varia +/- %1 digibit pentru fiecare intrare.</translation>
     </message>
     <message>
         <source>(no label)</source>
@@ -2074,10 +2074,10 @@
     <message>
         <source>Specify a custom fee per kB (1,000 bytes) of the transaction's virtual size.
 
-Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis per kB" for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 satoshis.</source>
+Note:  Since the fee is calculated on a per-byte basis, a fee of "100 digibits per kB" for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 digibits.</source>
         <translation>Specificati o taxa anume pe kB (1000 byte) din marimea virtuala a tranzactiei. 
 
-Nota: Cum taxa este calculata per byte, o taxa de "100 satoshi per kB" pentru o tranzactie de 500 byte (jumatate de kB) va produce o taxa de doar 50 satoshi.</translation>
+Nota: Cum taxa este calculata per byte, o taxa de "100 digibit per kB" pentru o tranzactie de 500 byte (jumatate de kB) va produce o taxa de doar 50 digibit.</translation>
     </message>
     <message>
         <source>per kilobyte</source>

--- a/src/qt/locale/digibyte_ro_RO.ts
+++ b/src/qt/locale/digibyte_ro_RO.ts
@@ -753,8 +753,8 @@
         <translation>Această etichetă devine roşie, dacă orice beneficiar primeşte o sumă mai mică decât pragul curent pentru praf.</translation>
     </message>
     <message>
-        <source>Can vary +/- %1 satoshi(s) per input.</source>
-        <translation>Poate varia +/- %1 satoshi pentru fiecare intrare.</translation>
+        <source>Can vary +/- %1 digibit(s) per input.</source>
+        <translation>Poate varia +/- %1 digibit pentru fiecare intrare.</translation>
     </message>
     <message>
         <source>(no label)</source>
@@ -2086,10 +2086,10 @@
     <message>
         <source>Specify a custom fee per kB (1,000 bytes) of the transaction's virtual size.
 
-Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis per kB" for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 satoshis.</source>
+Note:  Since the fee is calculated on a per-byte basis, a fee of "100 digibits per kB" for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 digibits.</source>
         <translation>Specificati o taxa anume pe kB (1000 byte) din marimea virtuala a tranzactiei. 
 
-Nota: Cum taxa este calculata per byte, o taxa de "100 satoshi per kB" pentru o tranzactie de 500 byte (jumatate de kB) va produce o taxa de doar 50 satoshi.</translation>
+Nota: Cum taxa este calculata per byte, o taxa de "100 digibit per kB" pentru o tranzactie de 500 byte (jumatate de kB) va produce o taxa de doar 50 digibit.</translation>
     </message>
     <message>
         <source>per kilobyte</source>

--- a/src/qt/locale/digibyte_sk.ts
+++ b/src/qt/locale/digibyte_sk.ts
@@ -761,8 +761,8 @@
         <translation>Tento popis sčervenie ak ktorýkoľvek príjemca dostane sumu menšiu ako súčasný limit pre "prach".</translation>
     </message>
     <message>
-        <source>Can vary +/- %1 satoshi(s) per input.</source>
-        <translation>Môže sa líšiť o +/- %1 satoshi pre každý vstup.</translation>
+        <source>Can vary +/- %1 digibit(s) per input.</source>
+        <translation>Môže sa líšiť o +/- %1 digibit pre každý vstup.</translation>
     </message>
     <message>
         <source>(no label)</source>
@@ -2211,10 +2211,10 @@
     <message>
         <source>Specify a custom fee per kB (1,000 bytes) of the transaction's virtual size.
 
-Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis per kB" for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 satoshis.</source>
+Note:  Since the fee is calculated on a per-byte basis, a fee of "100 digibits per kB" for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 digibits.</source>
         <translation>Špecifikujte vlastný poplatok za kB (1000 bajtov) virtuálnej veľkosti transakcie.
 
-Poznámka: Keďže poplatok je počítaný za bajt, poplatok o hodnote "100 satoshi za kB" a veľkosti transakcie 500 bajtov (polovica z 1 kB) by stál len 50 satoshi.</translation>
+Poznámka: Keďže poplatok je počítaný za bajt, poplatok o hodnote "100 digibit za kB" a veľkosti transakcie 500 bajtov (polovica z 1 kB) by stál len 50 digibit.</translation>
     </message>
     <message>
         <source>per kilobyte</source>

--- a/src/qt/locale/digibyte_sl.ts
+++ b/src/qt/locale/digibyte_sl.ts
@@ -807,8 +807,8 @@ Podpisovanje je možno le s podedovanimi ("legacy") naslovi.</translation>
         <translation>Ta oznaka se spremeni v rdeče, če katerikoli prejemnik prejme znesek, ki je manjši od trenutnega praga za prah.</translation>
     </message>
     <message>
-        <source>Can vary +/- %1 satoshi(s) per input.</source>
-        <translation>Se lahko razlikuje +/- %1 satoši(jev) na vhod.</translation>
+        <source>Can vary +/- %1 digibit(s) per input.</source>
+        <translation>Se lahko razlikuje +/- %1 digibit(jev) na vhod.</translation>
     </message>
     <message>
         <source>(no label)</source>
@@ -2404,10 +2404,10 @@ Podpisovanje je možno le s podedovanimi ("legacy") naslovi.</translation>
     <message>
         <source>Specify a custom fee per kB (1,000 bytes) of the transaction's virtual size.
 
-Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis per kB" for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 satoshis.</source>
+Note:  Since the fee is calculated on a per-byte basis, a fee of "100 digibits per kB" for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 digibits.</source>
         <translation>Določite poljubno provizijo na kB (1000 bajtov) navidezne velikosti transakcije.
 
-Opomba: Ker se provizija izračuna na bajt, bi provizija "100 satoshijev na kB" za transakcijo velikosti 500 bajtov (polovica enega kB) znašala 50 satošijev.</translation>
+Opomba: Ker se provizija izračuna na bajt, bi provizija "100 digibitjev na kB" za transakcijo velikosti 500 bajtov (polovica enega kB) znašala 50 digibitjev.</translation>
     </message>
     <message>
         <source>per kilobyte</source>

--- a/src/qt/locale/digibyte_sv.ts
+++ b/src/qt/locale/digibyte_sv.ts
@@ -762,8 +762,8 @@ Försök igen.</translation>
         <translation>Denna etikett blir röd om någon mottagare tar emot ett belopp som är lägre än aktuell dammtröskel.</translation>
     </message>
     <message>
-        <source>Can vary +/- %1 satoshi(s) per input.</source>
-        <translation>Kan variera +/- %1 satoshi per inmatning.</translation>
+        <source>Can vary +/- %1 digibit(s) per input.</source>
+        <translation>Kan variera +/- %1 digibit per inmatning.</translation>
     </message>
     <message>
         <source>(no label)</source>
@@ -2187,10 +2187,10 @@ Försök igen.</translation>
     <message>
         <source>Specify a custom fee per kB (1,000 bytes) of the transaction's virtual size.
 
-Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis per kB" for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 satoshis.</source>
+Note:  Since the fee is calculated on a per-byte basis, a fee of "100 digibits per kB" for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 digibits.</source>
         <translation>Ange en egen avgift per kB (1 000 bytes) av transaktionens virtuella storlek.
 
-Notera: Då avgiften beräknas per byte kommer en avgift på 50 satoshi tas ut för en transaktion på 500 bytes (en halv kB) om man valt "100 satoshi per kB" som egen avgift.</translation>
+Notera: Då avgiften beräknas per byte kommer en avgift på 50 digibit tas ut för en transaktion på 500 bytes (en halv kB) om man valt "100 digibit per kB" som egen avgift.</translation>
     </message>
     <message>
         <source>per kilobyte</source>

--- a/src/qt/locale/digibyte_uk.ts
+++ b/src/qt/locale/digibyte_uk.ts
@@ -807,7 +807,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation>Ця позначка стане червоною, якщо будь-який отримувач отримає суму, меншу за поточний поріг пилу.</translation>
     </message>
     <message>
-        <source>Can vary +/- %1 satoshi(s) per input.</source>
+        <source>Can vary +/- %1 digibit(s) per input.</source>
         <translation>Може відрізнятися на +/- %1 сатоші за введені</translation>
     </message>
     <message>
@@ -2400,7 +2400,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Specify a custom fee per kB (1,000 bytes) of the transaction's virtual size.
 
-Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis per kB" for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 satoshis.</source>
+Note:  Since the fee is calculated on a per-byte basis, a fee of "100 digibits per kB" for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 digibits.</source>
         <translation>Вкажіть комісію за кБ (1,000 байт) віртуального розміру транзакції.
 
 Примітка: Так як комісія нараховується за байт, комісія "100 сатоші за кБ" для транзакції розміром 500 байт (пів 1 кБ) буде приблизно 50 сатоші.</translation>

--- a/src/qt/locale/digibyte_vi.ts
+++ b/src/qt/locale/digibyte_vi.ts
@@ -761,8 +761,8 @@
         <translation>Label này chuyển sang đỏ nếu bất cứ giao dịch nhận nào có số lượng nhỏ hơn ngưỡng dust.</translation>
     </message>
     <message>
-        <source>Can vary +/- %1 satoshi(s) per input.</source>
-        <translation>Có thể thay đổi +/-%1 satoshi(s) trên input.</translation>
+        <source>Can vary +/- %1 digibit(s) per input.</source>
+        <translation>Có thể thay đổi +/-%1 digibit(s) trên input.</translation>
     </message>
     <message>
         <source>(no label)</source>
@@ -2194,10 +2194,10 @@
     <message>
         <source>Specify a custom fee per kB (1,000 bytes) of the transaction's virtual size.
 
-Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis per kB" for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 satoshis.</source>
+Note:  Since the fee is calculated on a per-byte basis, a fee of "100 digibits per kB" for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 digibits.</source>
         <translation>Chỉ định một khoản phí tùy chỉnh cho mỗi kB (1.000 byte) kích thước ảo của giao dịch.
 
-Lưu ý: Vì phí được tính trên cơ sở mỗi byte, nên phí "100 satoshi trên mỗi kB" cho kích thước giao dịch là 500 byte (một nửa của 1 kB) cuối cùng sẽ mang lại một khoản phí chỉ 50 satoshi.</translation>
+Lưu ý: Vì phí được tính trên cơ sở mỗi byte, nên phí "100 digibit trên mỗi kB" cho kích thước giao dịch là 500 byte (một nửa của 1 kB) cuối cùng sẽ mang lại một khoản phí chỉ 50 digibit.</translation>
     </message>
     <message>
         <source>per kilobyte</source>

--- a/src/qt/locale/digibyte_zh.ts
+++ b/src/qt/locale/digibyte_zh.ts
@@ -745,8 +745,8 @@
         <translation>如果任何接收方接收到的金额小于当前粉尘交易的阈值，则此标签将变为红色。</translation>
     </message>
     <message>
-        <source>Can vary +/- %1 satoshi(s) per input.</source>
-        <translation>每个输入可以改变+/- %1 satoshi(s)。</translation>
+        <source>Can vary +/- %1 digibit(s) per input.</source>
+        <translation>每个输入可以改变+/- %1 digibit(s)。</translation>
     </message>
     <message>
         <source>(no label)</source>
@@ -1182,9 +1182,9 @@
     <message>
         <source>Specify a custom fee per kB (1,000 bytes) of the transaction's virtual size.
 
-Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis per kB" for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 satoshis.</source>
+Note:  Since the fee is calculated on a per-byte basis, a fee of "100 digibits per kB" for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 digibits.</source>
         <translation>指定交易虚拟大小的每kB(1,000字节)的自定义费用。
-注意:由于费用是按字节计算的，对于大小为500字节(1 kB的一半)的交易，“每kB 100 satoshis”的费用最终只会产生50 satoshis的费用。</translation>
+注意:由于费用是按字节计算的，对于大小为500字节(1 kB的一半)的交易，“每kB 100 digibits”的费用最终只会产生50 digibits的费用。</translation>
     </message>
     <message>
         <source>Hide</source>

--- a/src/qt/locale/digibyte_zh_CN.ts
+++ b/src/qt/locale/digibyte_zh_CN.ts
@@ -807,8 +807,8 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation>当任何一个收款金额小于目前的粉尘金额阈值时，文字会变红色。</translation>
     </message>
     <message>
-        <source>Can vary +/- %1 satoshi(s) per input.</source>
-        <translation>每个输入可能有 +/- %1 聪 (satoshi) 的误差。</translation>
+        <source>Can vary +/- %1 digibit(s) per input.</source>
+        <translation>每个输入可能有 +/- %1 聪 (digibit) 的误差。</translation>
     </message>
     <message>
         <source>(no label)</source>
@@ -2404,7 +2404,7 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Specify a custom fee per kB (1,000 bytes) of the transaction's virtual size.
 
-Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis per kB" for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 satoshis.</source>
+Note:  Since the fee is calculated on a per-byte basis, a fee of "100 digibits per kB" for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 digibits.</source>
         <translation>按照交易的虚拟大小自定义每kB ( 1,000 字节 )要交多少手续费。
 
 注意:手续费是按照字节数计算的，对于一笔大小为500字节（1kB的一半）的交易来说，"每kB付100聪手续费"就意味着手续费一共只付了50聪。</translation>

--- a/src/qt/locale/digibyte_zh_TW.ts
+++ b/src/qt/locale/digibyte_zh_TW.ts
@@ -798,8 +798,8 @@ Signing is only possible with addresses of the type 'legacy'.</source>
         <translation>當任何一個收款金額小於目前的灰塵金額上限時，文字會變紅色。</translation>
     </message>
     <message>
-        <source>Can vary +/- %1 satoshi(s) per input.</source>
-        <translation>每組輸入可能有 +/- %1 個 satoshi 的誤差。</translation>
+        <source>Can vary +/- %1 digibit(s) per input.</source>
+        <translation>每組輸入可能有 +/- %1 個 digibit 的誤差。</translation>
     </message>
     <message>
         <source>(no label)</source>
@@ -2343,10 +2343,10 @@ Signing is only possible with addresses of the type 'legacy'.</source>
     <message>
         <source>Specify a custom fee per kB (1,000 bytes) of the transaction's virtual size.
 
-Note:  Since the fee is calculated on a per-byte basis, a fee of "100 satoshis per kB" for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 satoshis.</source>
+Note:  Since the fee is calculated on a per-byte basis, a fee of "100 digibits per kB" for a transaction size of 500 bytes (half of 1 kB) would ultimately yield a fee of only 50 digibits.</source>
         <translation>指定每一千位元祖(kB)擬真大小的交易所要付出的手續費。
 
-注意: 交易手續費是以位元組為單位來計算。因此當指定手續費為每千位元組 100 個 satoshi 時，對於一筆大小為 500 位元組(一千位元組的一半)的交易，其手續費會只有  50 個 satoshi。</translation>
+注意: 交易手續費是以位元組為單位來計算。因此當指定手續費為每千位元組 100 個 digibit 時，對於一筆大小為 500 位元組(一千位元組的一半)的交易，其手續費會只有  50 個 digibit。</translation>
     </message>
     <message>
         <source>per kilobyte</source>

--- a/test/functional/README.md
+++ b/test/functional/README.md
@@ -68,7 +68,7 @@ don't have test cases for.
   load a premined blockchain from cache with the default value of `False`. The
   cached data directories contain a 200-block pre-mined blockchain with the
   spendable mining rewards being split between four nodes. Each node has 25
-  mature block subsidies (25x50=1250 BTC) in its wallet. Using them is much more
+  mature block subsidies (25x50=1250 DGB) in its wallet. Using them is much more
   efficient than mining blocks in your test.
 - When calling RPCs with lots of arguments, consider using named keyword
   arguments instead of positional arguments to make the intent of the call

--- a/test/functional/feature_bip68_sequence.py
+++ b/test/functional/feature_bip68_sequence.py
@@ -87,7 +87,7 @@ class BIP68Test(DigiByteTestFramework):
     def test_disable_flag(self):
         # Create some unconfirmed inputs
         new_addr = self.nodes[0].getnewaddress()
-        self.nodes[0].sendtoaddress(new_addr, 2) # send 2 BTC
+        self.nodes[0].sendtoaddress(new_addr, 2) # send 2 DGB
 
         utxos = self.nodes[0].listunspent(0, 0)
         assert len(utxos) > 0

--- a/test/functional/feature_block.py
+++ b/test/functional/feature_block.py
@@ -495,7 +495,7 @@ class FullBlockTest(DigiByteTestFramework):
         redeem_script = CScript([self.coinbase_pubkey] + [OP_2DUP, OP_CHECKSIGVERIFY] * 5 + [OP_CHECKSIG])
         p2sh_script = script_to_p2sh_script(redeem_script)
 
-        # Create a transaction that spends one satoshi to the p2sh_script, the rest to OP_TRUE
+        # Create a transaction that spends one digibit to the p2sh_script, the rest to OP_TRUE
         # This must be signed because it is spending a coinbase
         spend = out[11]
         tx = self.create_tx(spend, 0, 1, p2sh_script)
@@ -505,7 +505,7 @@ class FullBlockTest(DigiByteTestFramework):
         b39 = self.update_block(39, [tx])
         b39_outputs += 1
 
-        # Until block is full, add tx's with 1 satoshi to p2sh_script, the rest to OP_TRUE
+        # Until block is full, add tx's with 1 digibit to p2sh_script, the rest to OP_TRUE
         tx_new = None
         tx_last = tx
         total_weight = b39.get_weight()
@@ -1010,11 +1010,11 @@ class FullBlockTest(DigiByteTestFramework):
         # -> b64 (18) -> b65 (19) -> b69 (20)
         #                        \-> b68 (20)
         #
-        # b68 - coinbase with an extra 10 satoshis,
-        #       creates a tx that has 9 satoshis from out[20] go to fees
-        #       this fails because the coinbase is trying to claim 1 satoshi too much in fees
+        # b68 - coinbase with an extra 10 digibits,
+        #       creates a tx that has 9 digibits from out[20] go to fees
+        #       this fails because the coinbase is trying to claim 1 digibit too much in fees
         #
-        # b69 - coinbase with extra 10 satoshis, and a tx that gives a 10 satoshi fee
+        # b69 - coinbase with extra 10 digibits, and a tx that gives a 10 digibit fee
         #       this succeeds
         #
         self.log.info("Reject a block trying to claim too much subsidy in the coinbase transaction")
@@ -1381,9 +1381,9 @@ class FullBlockTest(DigiByteTestFramework):
         if spend is None:
             block = create_block(base_block_hash, coinbase, block_time, version=version)
         else:
-            coinbase.vout[0].nValue += spend.vout[0].nValue - 1  # all but one satoshi to fees
+            coinbase.vout[0].nValue += spend.vout[0].nValue - 1  # all but one digibit to fees
             coinbase.rehash()
-            tx = self.create_tx(spend, 0, 1, script)  # spend 1 satoshi
+            tx = self.create_tx(spend, 0, 1, script)  # spend 1 digibit
             self.sign_tx(tx, spend)
             tx.rehash()
             block = create_block(base_block_hash, coinbase, block_time, version=version, txlist=[tx])

--- a/test/functional/feature_coinstatsindex.py
+++ b/test/functional/feature_coinstatsindex.py
@@ -160,7 +160,7 @@ class CoinStatsIndexTest(DigiByteTestFramework):
         signed_tx1 = self.nodes[0].signrawtransactionwithwallet(funded_tx1['hex'])
         tx1_txid = self.nodes[0].sendrawtransaction(signed_tx1['hex'])
 
-        # Find the right position of the 21 BTC output
+        # Find the right position of the 21 DGB output
         tx1_final = self.nodes[0].gettransaction(tx1_txid)
         for output in tx1_final['details']:
             if output['amount'] == Decimal('21.00000000') and output['category'] == 'receive':

--- a/test/functional/feature_fee_estimation.py
+++ b/test/functional/feature_fee_estimation.py
@@ -30,7 +30,7 @@ from test_framework.util import (
     assert_greater_than,
     assert_greater_than_or_equal,
     assert_raises_rpc_error,
-    satoshi_round,
+    digibit_round,
 )
 
 # Construct 2 trivial P2SH's and the ScriptSigs that spend them
@@ -60,7 +60,7 @@ def small_txpuzzle_randfee(from_node, conflist, unconflist, amount, min_fee, fee
     # Exponentially distributed from 1-128 * fee_increment
     rand_fee = float(fee_increment) * (1.1892 ** random.randint(0, 28))
     # Total fee ranges from min_fee to min_fee + 127*fee_increment
-    fee = min_fee - fee_increment + satoshi_round(rand_fee)
+    fee = min_fee - fee_increment + digibit_round(rand_fee)
     tx = CTransaction()
     total_in = Decimal("0.00000000")
     while total_in <= (amount + fee) and len(conflist) > 0:
@@ -99,7 +99,7 @@ def split_inputs(from_node, txins, txouts, initial_split=False):
     tx = CTransaction()
     tx.vin.append(CTxIn(COutPoint(int(prevtxout["txid"], 16), prevtxout["vout"]), b""))
 
-    half_change = satoshi_round(prevtxout["amount"] / 2)
+    half_change = digibit_round(prevtxout["amount"] / 2)
     rem_change = prevtxout["amount"] - half_change - Decimal("0.00100000")
     tx.vout.append(CTxOut(int(half_change * COIN), P2SH_1))
     tx.vout.append(CTxOut(int(rem_change * COIN), P2SH_2))

--- a/test/functional/feature_rbf.py
+++ b/test/functional/feature_rbf.py
@@ -18,7 +18,7 @@ from test_framework.messages import (
 )
 from test_framework.script import CScript, OP_DROP
 from test_framework.test_framework import DigiByteTestFramework
-from test_framework.util import assert_equal, assert_raises_rpc_error, satoshi_round
+from test_framework.util import assert_equal, assert_raises_rpc_error, digibit_round
 from test_framework.script_util import DUMMY_P2WPKH_SCRIPT, DUMMY_2_P2WPKH_SCRIPT
 from test_framework.wallet import MiniWallet
 
@@ -52,11 +52,11 @@ class ReplaceByFeeTest(DigiByteTestFramework):
                     unconfirmed otherwise.
         """
         fee = 1 * COIN
-        while node.getbalance() < satoshi_round((amount + fee) / COIN):
+        while node.getbalance() < digibit_round((amount + fee) / COIN):
             self.generate(node, COINBASE_MATURITY)
 
         new_addr = node.getnewaddress()
-        txid = node.sendtoaddress(new_addr, satoshi_round((amount + fee) / COIN))
+        txid = node.sendtoaddress(new_addr, digibit_round((amount + fee) / COIN))
         tx1 = node.getrawtransaction(txid, 1)
         txid = int(txid, 16)
         i, _ = next(filter(lambda vout: new_addr == vout[1]['scriptPubKey']['address'], enumerate(tx1['vout'])))
@@ -154,7 +154,7 @@ class ReplaceByFeeTest(DigiByteTestFramework):
         # This will raise an exception due to insufficient fee
         assert_raises_rpc_error(-26, "insufficient fee", self.nodes[0].sendrawtransaction, tx1b_hex, 0)
 
-        # Extra 0.1 BTC fee
+        # Extra 0.1 DGB fee
         tx1b = CTransaction()
         tx1b.vin = [CTxIn(tx0_outpoint, nSequence=0)]
         tx1b.vout = [CTxOut(int(0.9 * COIN), DUMMY_P2WPKH_SCRIPT)]
@@ -189,7 +189,7 @@ class ReplaceByFeeTest(DigiByteTestFramework):
             prevout = COutPoint(int(txid, 16), 0)
 
         # Whether the double-spend is allowed is evaluated by including all
-        # child fees - 40 BTC - so this attempt is rejected.
+        # child fees - 40 DGB - so this attempt is rejected.
         dbl_tx = CTransaction()
         dbl_tx.vin = [CTxIn(tx0_outpoint, nSequence=0)]
         dbl_tx.vout = [CTxOut(initial_nValue - 30 * COIN, DUMMY_P2WPKH_SCRIPT)]
@@ -259,7 +259,7 @@ class ReplaceByFeeTest(DigiByteTestFramework):
         # This will raise an exception due to insufficient fee
         assert_raises_rpc_error(-26, "insufficient fee", self.nodes[0].sendrawtransaction, dbl_tx_hex, 0)
 
-        # 1 BTC fee is enough
+        # 1 DGB fee is enough
         dbl_tx = CTransaction()
         dbl_tx.vin = [CTxIn(tx0_outpoint, nSequence=0)]
         dbl_tx.vout = [CTxOut(initial_nValue - fee * n - 1 * COIN, DUMMY_P2WPKH_SCRIPT)]
@@ -638,7 +638,7 @@ class ReplaceByFeeTest(DigiByteTestFramework):
         tx = wallet.send_self_transfer(from_node=self.nodes[0])['tx']
 
         # Higher fee, higher feerate, different txid, but the replacement does not provide a relay
-        # fee conforming to node's `incrementalrelayfee` policy of 1000 sat per KB.
+        # fee conforming to node's `incrementalrelayfee` policy of 1000 dbit per KB.
         tx.vout[0].nValue -= 1
         assert_raises_rpc_error(-26, "insufficient fee", self.nodes[0].sendrawtransaction, tx.serialize().hex())
 

--- a/test/functional/mempool_limit.py
+++ b/test/functional/mempool_limit.py
@@ -64,7 +64,7 @@ class MempoolLimitTest(DigiByteTestFramework):
         tx_to_be_evicted_id = miniwallet.send_self_transfer(from_node=node, fee_rate=relayfee)["txid"]
 
         # Increase the tx fee rate to give the subsequent transactions a higher priority in the mempool
-        # The tx has an approx. vsize of 65k, i.e. multiplying the previous fee rate (in sats/kvB)
+        # The tx has an approx. vsize of 65k, i.e. multiplying the previous fee rate (in dbit/kvB)
         # by 130 should result in a fee that corresponds to 2x of that fee rate
         base_fee = relayfee * 130
 

--- a/test/functional/mempool_packages.py
+++ b/test/functional/mempool_packages.py
@@ -15,7 +15,7 @@ from test_framework.util import (
     assert_equal,
     assert_raises_rpc_error,
     chain_transaction,
-    satoshi_round,
+    digibit_round,
 )
 
 # default limits
@@ -197,10 +197,10 @@ class MempoolPackagesTest(DigiByteTestFramework):
         for x in reversed(chain):
             descendant_fees += mempool[x]['fee']
             if (x == chain[-1]):
-                assert_equal(mempool[x]['modifiedfee'], mempool[x]['fee']+satoshi_round(0.00002))
-                assert_equal(mempool[x]['fees']['modified'], mempool[x]['fee']+satoshi_round(0.00002))
+                assert_equal(mempool[x]['modifiedfee'], mempool[x]['fee']+digibit_round(0.00002))
+                assert_equal(mempool[x]['fees']['modified'], mempool[x]['fee']+digibit_round(0.00002))
             assert_equal(mempool[x]['descendantfees'], descendant_fees * COIN + 2000)
-            assert_equal(mempool[x]['fees']['descendant'], descendant_fees+satoshi_round(0.00002))
+            assert_equal(mempool[x]['fees']['descendant'], descendant_fees+digibit_round(0.00002))
 
         # Check that node1's mempool is as expected (-> custom ancestor limit)
         mempool0 = self.nodes[0].getrawmempool(False)
@@ -296,7 +296,7 @@ class MempoolPackagesTest(DigiByteTestFramework):
         value = utxo[0]['amount']
         vout = utxo[0]['vout']
 
-        send_value = satoshi_round((value - fee)/2)
+        send_value = digibit_round((value - fee)/2)
         inputs = [ {'txid' : txid, 'vout' : vout} ]
         outputs = {}
         for _ in range(2):

--- a/test/functional/p2p_dandelion.py
+++ b/test/functional/p2p_dandelion.py
@@ -9,7 +9,7 @@ Tests:
 1. Resistance to active probing:
     Stem:    0 --> 1 --> 2 --> 0 where each node has argument "-dandelion=1"
     Probe: TestNode --> 0
-    Node 0 generates a Dandelion transaction "tx": 1.0 BTC from Node 0 to Node 2
+    Node 0 generates a Dandelion transaction "tx": 1.0 DGB from Node 0 to Node 2
     TestNode immediately sends getdata for tx to Node 0
     Assert that Node 0 does not reply with tx
 

--- a/test/functional/p2p_feefilter.py
+++ b/test/functional/p2p_feefilter.py
@@ -86,21 +86,21 @@ class FeeFilterTest(DigiByteTestFramework):
 
         conn = self.nodes[0].add_p2p_connection(TestP2PConn())
 
-        self.log.info("Test txs paying 20 sat/byte are received by test connection")
+        self.log.info("Test txs paying 20 dbit/byte are received by test connection")
         TX_KEY = 'wtxid' if P2P_VERSION >= WTXID_RELAY_VERSION else 'txid'
         txids = [miniwallet.send_self_transfer(fee_rate=Decimal('0.000200'), from_node=node1)[TX_KEY] for _ in range(3)]
         conn.wait_for_invs_to_match(txids)
         conn.clear_invs()
 
-        # Set a fee filter of 0.15 sat/byte on test connection
+        # Set a fee filter of 0.15 dbit/byte on test connection
         conn.send_and_ping(msg_feefilter(150))
 
-        self.log.info("Test txs paying 0.15 sat/byte are received by test connection")
+        self.log.info("Test txs paying 0.15 dbit/byte are received by test connection")
         txids = [miniwallet.send_self_transfer(fee_rate=Decimal('0.00000150'), from_node=node1)[TX_KEY] for _ in range(3)]
         conn.wait_for_invs_to_match(txids)
         conn.clear_invs()
 
-        self.log.info("Test txs paying 0.1 sat/byte are no longer received by test connection")
+        self.log.info("Test txs paying 0.1 dbit/byte are no longer received by test connection")
         txids = [miniwallet.send_self_transfer(fee_rate=Decimal('0.00000100'), from_node=node1)[TX_KEY] for _ in range(3)]
         self.sync_mempools()  # must be sure node 0 has received all txs
 

--- a/test/functional/rpc_fundrawtransaction.py
+++ b/test/functional/rpc_fundrawtransaction.py
@@ -717,7 +717,7 @@ class RawTransactionsTest(DigiByteTestFramework):
         wwatch.unloadwallet()
 
     def test_option_feerate(self):
-        self.log.info("Test fundrawtxn with explicit fee rates (fee_rate sat/vB and feeRate DGB/kvB)")
+        self.log.info("Test fundrawtxn with explicit fee rates (fee_rate dbit/vB and feeRate DGB/kvB)")
         node = self.nodes[3]
         # Make sure there is exactly one input so coin selection can't skew the result.
         assert_equal(len(self.nodes[3].listunspent(1)), 1)
@@ -726,10 +726,10 @@ class RawTransactionsTest(DigiByteTestFramework):
         rawtx = node.createrawtransaction(inputs, outputs)
 
         result = node.fundrawtransaction(rawtx)  # uses self.min_relay_tx_fee (set by settxfee)
-        btc_kvb_to_sat_vb = 100000  # (1e5)
-        result1 = node.fundrawtransaction(rawtx, {"fee_rate": str(2 * btc_kvb_to_sat_vb * self.min_relay_tx_fee)})
+        dgb_kvb_to_dbit_vb = 100000  # (1e5)
+        result1 = node.fundrawtransaction(rawtx, {"fee_rate": str(2 * dgb_kvb_to_dbit_vb * self.min_relay_tx_fee)})
         result2 = node.fundrawtransaction(rawtx, {"feeRate": 2 * self.min_relay_tx_fee})
-        result3 = node.fundrawtransaction(rawtx, {"fee_rate": 10 * btc_kvb_to_sat_vb * self.min_relay_tx_fee})
+        result3 = node.fundrawtransaction(rawtx, {"fee_rate": 10 * dgb_kvb_to_dbit_vb * self.min_relay_tx_fee})
         result4 = node.fundrawtransaction(rawtx, {"feeRate": str(10 * self.min_relay_tx_fee)})
 
         result_fee_rate = result['fee'] * 10 / count_bytes(result['hex'])
@@ -742,7 +742,7 @@ class RawTransactionsTest(DigiByteTestFramework):
         for param, zero_value in product(["fee_rate", "feeRate"], [0, 0.000, 0.00000000, "0", "0.000", "0.00000000"]):
             assert_equal(self.nodes[3].fundrawtransaction(rawtx, {param: zero_value})["fee"], 0)
 
-        # With no arguments passed, expect fee of 14100 satoshis.
+        # With no arguments passed, expect fee of 14100 digibits.
         # Expect fee to be 100x higher when an explicit fee rate 100x greater is specified.
         result = node.fundrawtransaction(rawtx, {"fee_rate": 10000})
         assert_approx(result["fee"], vexp=0.0141, vspan=0.0001)
@@ -780,17 +780,17 @@ class RawTransactionsTest(DigiByteTestFramework):
             # Test fee rate values that don't pass fixed-point parsing checks.
             for invalid_value in ["", 0.000000001, 1e-09, 1.111111111, 1111111111111111, "31.999999999999999999999"]:
                 assert_raises_rpc_error(-3, "Invalid amount", node.fundrawtransaction, rawtx, {param: invalid_value, "add_inputs": True})
-        # Test fee_rate values that cannot be represented in sat/vB.
+        # Test fee_rate values that cannot be represented in dbit/vB.
         for invalid_value in [0.0001, 0.00000001, 0.00099999, 31.99999999, "0.0001", "0.00000001", "0.00099999", "31.99999999"]:
             assert_raises_rpc_error(-3, "Invalid amount",
                 node.fundrawtransaction, rawtx, {"fee_rate": invalid_value, "add_inputs": True})
 
-        self.log.info("Test min fee rate checks are bypassed with fundrawtxn, e.g. a fee_rate under 1 sat/vB is allowed")
+        self.log.info("Test min fee rate checks are bypassed with fundrawtxn, e.g. a fee_rate under 1 dbit/vB is allowed")
         node.fundrawtransaction(rawtx, {"fee_rate": 0.999, "add_inputs": True})
         node.fundrawtransaction(rawtx, {"feeRate": 0.00000999, "add_inputs": True})
 
         self.log.info("- raises RPC error if both feeRate and fee_rate are passed")
-        assert_raises_rpc_error(-8, "Cannot specify both fee_rate (sat/vB) and feeRate (DGB/kvB)",
+        assert_raises_rpc_error(-8, "Cannot specify both fee_rate (dbit/vB) and feeRate (DGB/kvB)",
             node.fundrawtransaction, rawtx, {"fee_rate": 0.1, "feeRate": 0.1, "add_inputs": True})
 
         self.log.info("- raises RPC error if both feeRate and estimate_mode passed")
@@ -852,13 +852,13 @@ class RawTransactionsTest(DigiByteTestFramework):
         assert_equal(output[3], output[4] + result[4]['fee'])
         assert_equal(change[3] + result[3]['fee'], change[4])
 
-        # Test subtract fee from outputs with fee_rate (sat/vB)
-        btc_kvb_to_sat_vb = 100000  # (1e5)
+        # Test subtract fee from outputs with fee_rate (dbit/vB)
+        dgb_kvb_to_dbit_vb = 100000  # (1e5)
         result = [self.nodes[3].fundrawtransaction(rawtx),  # uses self.min_relay_tx_fee (set by settxfee)
             self.nodes[3].fundrawtransaction(rawtx, {"subtractFeeFromOutputs": []}),  # empty subtraction list
             self.nodes[3].fundrawtransaction(rawtx, {"subtractFeeFromOutputs": [0]}),  # uses self.min_relay_tx_fee (set by settxfee)
-            self.nodes[3].fundrawtransaction(rawtx, {"fee_rate": 2 * btc_kvb_to_sat_vb * self.min_relay_tx_fee}),
-            self.nodes[3].fundrawtransaction(rawtx, {"fee_rate": 2 * btc_kvb_to_sat_vb * self.min_relay_tx_fee, "subtractFeeFromOutputs": [0]}),]
+            self.nodes[3].fundrawtransaction(rawtx, {"fee_rate": 2 * dgb_kvb_to_dbit_vb * self.min_relay_tx_fee}),
+            self.nodes[3].fundrawtransaction(rawtx, {"fee_rate": 2 * dgb_kvb_to_dbit_vb * self.min_relay_tx_fee, "subtractFeeFromOutputs": [0]}),]
         dec_tx = [self.nodes[3].decoderawtransaction(tx_['hex']) for tx_ in result]
         output = [d['vout'][1 - r['changepos']]['value'] for d, r in zip(dec_tx, result)]
         change = [d['vout'][r['changepos']]['value'] for d, r in zip(dec_tx, result)]
@@ -902,7 +902,7 @@ class RawTransactionsTest(DigiByteTestFramework):
         assert_equal(share[2], share[3])
 
         # Output 0 takes at least as much share of the fee, and no more than 2
-        # satoshis more, than outputs 2 and 3.
+        # digibits more, than outputs 2 and 3.
         assert_greater_than_or_equal(share[0], share[2])
         assert_greater_than_or_equal(share[2] + Decimal(2e-8), share[0])
 
@@ -1049,13 +1049,13 @@ class RawTransactionsTest(DigiByteTestFramework):
         self.sync_all()
 
         # A P2WPKH input costs 68 vbytes; With a single P2WPKH output, the rest of the tx is 42 vbytes for a total of 110 vbytes.
-        # At a feerate of 1.85 sat/vb, the input will need a fee of 125.8 sats and the rest 77.7 sats
-        # The entire tx fee should be 203.5 sats.
+        # At a feerate of 1.85 dbit/vb, the input will need a fee of 125.8 dbits and the rest 77.7 dbits
+        # The entire tx fee should be 203.5 dbits.
         # Coin selection rounds the fee individually instead of at the end (due to how CFeeRate::GetFee works).
         # If rounding down (which is the incorrect behavior), then the calculated fee will be 125 + 77 = 202.
         # If rounding up, then the calculated fee will be 126 + 78 = 204.
         # In the former case, the calculated needed fee is higher than the actual fee being paid, so an assertion is reached
-        # To test this does not happen, we subtract 202 sats from the input value. If working correctly, this should
+        # To test this does not happen, we subtract 202 dbits from the input value. If working correctly, this should
         # fail with insufficient funds rather than digibyted asserting.
         rawtx = w.createrawtransaction(inputs=[], outputs=[{self.nodes[0].getnewaddress(address_type="bech32"): 1 - 0.00000202}])
         assert_raises_rpc_error(-4, "Insufficient funds", w.fundrawtransaction, rawtx, {"fee_rate": 1.85})

--- a/test/functional/rpc_psbt.py
+++ b/test/functional/rpc_psbt.py
@@ -189,13 +189,13 @@ class PSBTTest(DigiByteTestFramework):
         assert_equal(walletprocesspsbt_out['complete'], True)
         self.nodes[1].sendrawtransaction(self.nodes[1].finalizepsbt(walletprocesspsbt_out['psbt'])['hex'])
 
-        self.log.info("Test walletcreatefundedpsbt fee rate of 10000 sat/vB and 0.1 DGB/kvB produces a total fee at or slightly below -maxtxfee (~0.05290000)")
+        self.log.info("Test walletcreatefundedpsbt fee rate of 10000 dbit/vB and 0.1 DGB/kvB produces a total fee at or slightly below -maxtxfee (~0.05290000)")
         res1 = self.nodes[1].walletcreatefundedpsbt(inputs, outputs, 0, {"fee_rate": 100000, "add_inputs": True})
         assert_approx(res1["fee"], 0.0055, 0.5)
         res2 = self.nodes[1].walletcreatefundedpsbt(inputs, outputs, 0, {"feeRate": "0.1", "add_inputs": True})
         assert_approx(res2["fee"], 0.0055, 0.5)
 
-        self.log.info("Test min fee rate checks with walletcreatefundedpsbt are bypassed, e.g. a fee_rate under 1 sat/vB is allowed")
+        self.log.info("Test min fee rate checks with walletcreatefundedpsbt are bypassed, e.g. a fee_rate under 1 dbit/vB is allowed")
         res3 = self.nodes[1].walletcreatefundedpsbt(inputs, outputs, 0, {"fee_rate": "0.999", "add_inputs": True})
         assert_approx(res3["fee"], 0.00000381, 0.0000001)
         res4 = self.nodes[1].walletcreatefundedpsbt(inputs, outputs, 0, {"feeRate": 0.00000999, "add_inputs": True})
@@ -217,13 +217,13 @@ class PSBTTest(DigiByteTestFramework):
             for invalid_value in ["", 0.000000001, 1e-09, 1.111111111, 1111111111111111, "31.999999999999999999999"]:
                 assert_raises_rpc_error(-3, "Invalid amount",
                     self.nodes[1].walletcreatefundedpsbt, inputs, outputs, 0, {param: invalid_value, "add_inputs": True})
-        # Test fee_rate values that cannot be represented in sat/vB.
+        # Test fee_rate values that cannot be represented in dbit/vB.
         for invalid_value in [0.0001, 0.00000001, 0.00099999, 31.99999999, "0.0001", "0.00000001", "0.00099999", "31.99999999"]:
             assert_raises_rpc_error(-3, "Invalid amount",
                 self.nodes[1].walletcreatefundedpsbt, inputs, outputs, 0, {"fee_rate": invalid_value, "add_inputs": True})
 
         self.log.info("- raises RPC error if both feeRate and fee_rate are passed")
-        assert_raises_rpc_error(-8, "Cannot specify both fee_rate (sat/vB) and feeRate (DGB/kvB)",
+        assert_raises_rpc_error(-8, "Cannot specify both fee_rate (dbit/vB) and feeRate (DGB/kvB)",
             self.nodes[1].walletcreatefundedpsbt, inputs, outputs, 0, {"fee_rate": 0.1, "feeRate": 0.1, "add_inputs": True})
 
         self.log.info("- raises RPC error if both feeRate and estimate_mode passed")

--- a/test/functional/rpc_rawtransaction.py
+++ b/test/functional/rpc_rawtransaction.py
@@ -320,12 +320,12 @@ class RawTransactionsTest(DigiByteTestFramework):
 
         self.sync_all()
         inputs = [{"txid": txId, "vout": vout['n']}]
-        # Fee 100,000 satoshis, (1 - (100000 sat * 0.00000001 BTC/sat)) = 0.999
+        # Fee 100,000 digibits, (1 - (100000 dbit * 0.00000001 DGB/dbit)) = 0.999
         outputs = {self.nodes[0].getnewaddress(): Decimal("0.9990000")}
         rawTx = self.nodes[2].createrawtransaction(inputs, outputs)
         rawTxSigned = self.nodes[2].signrawtransactionwithwallet(rawTx)
         assert_equal(rawTxSigned['complete'], True)
-        # Fee 10,000 satoshis, ~100 b transaction, fee rate should land around 100 sat/byte = 0.00100000 BTC/kB
+        # Fee 10,000 digibits, ~100 b transaction, fee rate should land around 100 dbit/byte = 0.00100000 DGB/kB
         # Thus, testmempoolaccept should reject
         testres = self.nodes[2].testmempoolaccept([rawTxSigned['hex']], 0.0010000)[0]
         self.log.info(f"testmempoolaccept result: {testres}")
@@ -346,12 +346,12 @@ class RawTransactionsTest(DigiByteTestFramework):
 
         self.sync_all()
         inputs = [{"txid": txId, "vout": vout['n']}]
-        # Fee 2,000,000 satoshis, (1 - (2000000 sat * 0.00000001 BTC/sat)) = 0.98
+        # Fee 2,000,000 digibits, (1 - (2000000 digibit * 0.00000001 DGB/dbit)) = 0.98
         outputs = {self.nodes[0].getnewaddress() : Decimal("0.98000000")}
         rawTx = self.nodes[2].createrawtransaction(inputs, outputs)
         rawTxSigned = self.nodes[2].signrawtransactionwithwallet(rawTx)
         assert_equal(rawTxSigned['complete'], True)
-        # Fee 2,000,000 satoshis, ~100 b transaction, fee rate should land around 20,000 sat/byte = 0.20000000 BTC/kB
+        # Fee 2,000,000 digibits, ~100 b transaction, fee rate should land around 20,000 dbit/byte = 0.20000000 DGB/kB
         # Thus, testmempoolaccept should reject
         testres = self.nodes[2].testmempoolaccept([rawTxSigned['hex']])[0]
         self.log.info(f"testmempoolaccept result (high fee): {testres}")
@@ -436,7 +436,7 @@ class RawTransactionsTest(DigiByteTestFramework):
         # use balance deltas instead of absolute values
         bal = self.nodes[2].getbalance()
 
-        # send 1.2 BTC to msig adr
+        # send 1.2 DGB to msig adr
         txId = self.nodes[0].sendtoaddress(mSigObj, 1.2)
         self.sync_all()
         self.generate(self.nodes[0], 1)

--- a/test/functional/rpc_scantxoutset.py
+++ b/test/functional/rpc_scantxoutset.py
@@ -85,7 +85,7 @@ class ScantxoutsetTest(DigiByteTestFramework):
 
         self.log.info("Test extended key derivation.")
         # Run various scans, and verify that the sum of the amounts of the matches corresponds to the expected subset.
-        # Note that all amounts in the UTXO set are powers of 2 multiplied by 0.001 BTC, so each amounts uniquely identifies a subset.
+        # Note that all amounts in the UTXO set are powers of 2 multiplied by 0.001 DGB, so each amounts uniquely identifies a subset.
         assert_equal(self.nodes[0].scantxoutset("start", [ "combo(tprv8ZgxMBicQKsPd7Uf69XL1XwhmjHopUGep8GuEiJDZmbQz6o58LninorQAfcKZWARbtRtfnLcJ5MQ2AtHcQJCCRUcMRvmDUjyEmNUWwx8UbK/0'/0h/0h)"])['total_amount'], Decimal("0.008"))
         assert_equal(self.nodes[0].scantxoutset("start", [ "combo(tprv8ZgxMBicQKsPd7Uf69XL1XwhmjHopUGep8GuEiJDZmbQz6o58LninorQAfcKZWARbtRtfnLcJ5MQ2AtHcQJCCRUcMRvmDUjyEmNUWwx8UbK/0'/0'/1h)"])['total_amount'], Decimal("0.016"))
         assert_equal(self.nodes[0].scantxoutset("start", [ "combo(tprv8ZgxMBicQKsPd7Uf69XL1XwhmjHopUGep8GuEiJDZmbQz6o58LninorQAfcKZWARbtRtfnLcJ5MQ2AtHcQJCCRUcMRvmDUjyEmNUWwx8UbK/0h/0'/1500')"])['total_amount'], Decimal("0.032"))

--- a/test/functional/test_framework/messages.py
+++ b/test/functional/test_framework/messages.py
@@ -51,7 +51,7 @@ MAX_BLOCK_BASE_SIZE = 1000000
 MAX_BLOOM_FILTER_SIZE = 36000
 MAX_BLOOM_HASH_FUNCS = 50
 
-COIN = 100000000  # 1 btc in satoshis
+COIN = 100000000  # 1 dgb in digibits
 MAX_MONEY = 21000000000 * COIN
 
 BIP125_SEQUENCE_NUMBER = 0xfffffffd  # Sequence number that is rbf-opt-in (BIP 125) and csv-opt-out (BIP 68)

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -226,7 +226,7 @@ def ceildiv(a, b):
 
 def get_fee(tx_size, feerate_dgb_kvb):
     """Calculate the fee in DGB given a feerate is DGB/kvB. Reflects CFeeRate::GetFee"""
-    feerate_dbit_kvb = int(feerate_dgb_kvb * Decimal(1e8)) # Fee in digibit/kvb as an int to avoid float precision errors
+    feerate_dbit_kvb = int(feerate_dgb_kvb * Decimal(1e8)) # Fee in dbit/kvb as an int to avoid float precision errors
     target_fee_dbit = ceildiv(feerate_dbit_kvb * tx_size, 1000) # Round calculated fee up to nearest digibit
     return digibit_round(target_fee_dbit / Decimal(1e8)) # Truncate DGB result to nearest digibit
 

--- a/test/functional/test_framework/util.py
+++ b/test/functional/test_framework/util.py
@@ -35,15 +35,15 @@ def assert_approx(v, vexp, vspan=0.001):
         raise AssertionError("%s > [%s..%s]" % (str(v), str(vexp - vspan), str(vexp + vspan)))
 
 
-def assert_fee_amount(fee, tx_size, feerate_BTC_kvB):
+def assert_fee_amount(fee, tx_size, feerate_DGB_kvB):
     """Assert the fee is in range."""
-    target_fee = get_fee(tx_size, feerate_BTC_kvB)
+    target_fee = get_fee(tx_size, feerate_DGB_kvB)
     if fee < target_fee:
-        raise AssertionError("Fee of %s BTC too low! (Should be %s BTC)" % (str(fee), str(target_fee)))
+        raise AssertionError("Fee of %s DGB too low! (Should be %s DGB)" % (str(fee), str(target_fee)))
     # allow the wallet's estimation to be at most 2 bytes off
-    high_fee = get_fee(tx_size + 2, feerate_BTC_kvB)
+    high_fee = get_fee(tx_size + 2, feerate_DGB_kvB)
     if fee > high_fee:
-        raise AssertionError("Fee of %s BTC too high! (Should be %s BTC)" % (str(fee), str(target_fee)))
+        raise AssertionError("Fee of %s DGB too high! (Should be %s DGB)" % (str(fee), str(target_fee)))
 
 
 def assert_equal(thing1, thing2, *args):
@@ -198,10 +198,10 @@ def assert_array_result(object_array, to_match, expected, should_not_find=False)
 
 
 def check_json_precision():
-    """Make sure json library being used does not lose precision converting BTC values"""
+    """Make sure json library being used does not lose precision converting DGB values"""
     n = Decimal("20000000.00000003")
-    satoshis = int(json.loads(json.dumps(float(n))) * 1.0e8)
-    if satoshis != 2000000000000003:
+    digibits = int(json.loads(json.dumps(float(n))) * 1.0e8)
+    if digibits != 2000000000000003:
         raise RuntimeError("JSON encode/decode loses precision")
 
 
@@ -224,14 +224,14 @@ def ceildiv(a, b):
     return -(-a // b)
 
 
-def get_fee(tx_size, feerate_btc_kvb):
-    """Calculate the fee in BTC given a feerate is BTC/kvB. Reflects CFeeRate::GetFee"""
-    feerate_sat_kvb = int(feerate_btc_kvb * Decimal(1e8)) # Fee in sat/kvb as an int to avoid float precision errors
-    target_fee_sat = ceildiv(feerate_sat_kvb * tx_size, 1000) # Round calculated fee up to nearest sat
-    return satoshi_round(target_fee_sat / Decimal(1e8)) # Truncate BTC result to nearest sat
+def get_fee(tx_size, feerate_dgb_kvb):
+    """Calculate the fee in DGB given a feerate is DGB/kvB. Reflects CFeeRate::GetFee"""
+    feerate_dbit_kvb = int(feerate_dgb_kvb * Decimal(1e8)) # Fee in digibit/kvb as an int to avoid float precision errors
+    target_fee_dbit = ceildiv(feerate_dbit_kvb * tx_size, 1000) # Round calculated fee up to nearest digibit
+    return digibit_round(target_fee_dbit / Decimal(1e8)) # Truncate DGB result to nearest digibit
 
 
-def satoshi_round(amount):
+def digibit_round(amount):
     return Decimal(amount).quantize(Decimal('0.00000001'), rounding=ROUND_DOWN)
 
 
@@ -489,8 +489,8 @@ def create_confirmed_utxos(test_framework, fee, node, count, **kwargs):
         inputs.append({"txid": t["txid"], "vout": t["vout"]})
         outputs = {}
         send_value = t['amount'] - fee
-        outputs[addr1] = satoshi_round(send_value / 2)
-        outputs[addr2] = satoshi_round(send_value / 2)
+        outputs[addr1] = digibit_round(send_value / 2)
+        outputs[addr2] = digibit_round(send_value / 2)
         raw_tx = node.createrawtransaction(inputs, outputs)
         signed_tx = node.signrawtransactionwithwallet(raw_tx)["hex"]
         node.sendrawtransaction(signed_tx)
@@ -510,7 +510,7 @@ def chain_transaction(node, parent_txids, vouts, value, fee, num_outputs, max_fe
 
     Returns a tuple with the txid and the amount sent per output.
     """
-    send_value = satoshi_round((value - fee)/num_outputs)
+    send_value = digibit_round((value - fee)/num_outputs)
     inputs = []
     for (txid, vout) in zip(parent_txids, vouts):
         inputs.append({'txid' : txid, 'vout' : vout})
@@ -556,7 +556,7 @@ def create_lots_of_big_transactions(node, txouts, utxos, num, fee):
         inputs = [{"txid": t["txid"], "vout": t["vout"]}]
         outputs = {}
         change = t['amount'] - fee
-        outputs[addr] = satoshi_round(change)
+        outputs[addr] = digibit_round(change)
         rawtx = node.createrawtransaction(inputs, outputs)
         tx = tx_from_hex(rawtx)
         for txout in txouts:

--- a/test/functional/test_framework/wallet.py
+++ b/test/functional/test_framework/wallet.py
@@ -28,7 +28,7 @@ from test_framework.script import (
 from test_framework.util import (
     assert_equal,
     hex_str_to_bytes,
-    satoshi_round,
+    digibit_round,
 )
 
 class MiniWalletMode(Enum):
@@ -145,7 +145,7 @@ class MiniWallet:
             vsize = Decimal(96)  # anyone-can-spend
         else:
             vsize = Decimal(168)  # P2PK (73 bytes scriptSig + 35 bytes scriptPubKey + 60 bytes other)
-        send_value = satoshi_round(utxo_to_spend['value'] - fee_rate * (vsize / 1000))
+        send_value = digibit_round(utxo_to_spend['value'] - fee_rate * (vsize / 1000))
         fee = utxo_to_spend['value'] - send_value
         assert send_value > 0
 

--- a/test/functional/wallet_abandonconflict.py
+++ b/test/functional/wallet_abandonconflict.py
@@ -49,13 +49,13 @@ class AbandonConflictTest(DigiByteTestFramework):
         # Disconnect nodes so node0's transactions don't get into node1's mempool
         self.disconnect_nodes(0, 1)
 
-        # Identify the 10btc outputs
+        # Identify the 10dgb outputs
         nA = next(tx_out["vout"] for tx_out in self.nodes[0].gettransaction(txA)["details"] if tx_out["amount"] == Decimal("10"))
         nB = next(tx_out["vout"] for tx_out in self.nodes[0].gettransaction(txB)["details"] if tx_out["amount"] == Decimal("10"))
         nC = next(tx_out["vout"] for tx_out in self.nodes[0].gettransaction(txC)["details"] if tx_out["amount"] == Decimal("10"))
 
         inputs = []
-        # spend 10btc outputs from txA and txB
+        # spend 10dgb outputs from txA and txB
         inputs.append({"txid": txA, "vout": nA})
         inputs.append({"txid": txB, "vout": nB})
         outputs = {}
@@ -65,7 +65,7 @@ class AbandonConflictTest(DigiByteTestFramework):
         signed = self.nodes[0].signrawtransactionwithwallet(self.nodes[0].createrawtransaction(inputs, outputs))
         txAB1 = self.nodes[0].sendrawtransaction(signed["hex"])
 
-        # Identify the 14.99998btc output
+        # Identify the 14.99998dgb output
         nAB = next(tx_out["vout"] for tx_out in self.nodes[0].gettransaction(txAB1)["details"] if tx_out["amount"] == Decimal("14.998"))
 
         #Create a child tx spending AB1 and C
@@ -200,13 +200,13 @@ class AbandonConflictTest(DigiByteTestFramework):
             assert_equal(double_spend["walletconflicts"], [tx["txid"]])
             assert_equal(tx["walletconflicts"], [double_spend["txid"]])
 
-        # Verify that B and C's 10 BTC outputs are available for spending again because AB1 is now conflicted
+        # Verify that B and C's 10 DGB outputs are available for spending again because AB1 is now conflicted
         newbalance = self.nodes[0].getbalance()
         assert_equal(newbalance, balance + Decimal("20"))
         balance = newbalance
 
         # There is currently a minor bug around this and so this test doesn't work.  See Issue #7315
-        # Invalidate the block with the double spend and B's 10 BTC output should no longer be available
+        # Invalidate the block with the double spend and B's 10 DGB output should no longer be available
         # Don't think C's should either
         self.nodes[0].invalidateblock(self.nodes[0].getbestblockhash())
         newbalance = self.nodes[0].getbalance()

--- a/test/functional/wallet_avoidreuse.py
+++ b/test/functional/wallet_avoidreuse.py
@@ -163,8 +163,8 @@ class AvoidReuseTest(DigiByteTestFramework):
 
     def test_sending_from_reused_address_without_avoid_reuse(self):
         '''
-        Test the same as test_sending_from_reused_address_fails, except send the 10 BTC with
-        the avoid_reuse flag set to false. This means the 10 BTC send should succeed,
+        Test the same as test_sending_from_reused_address_fails, except send the 10 DGB with
+        the avoid_reuse flag set to false. This means the 10 DGB send should succeed,
         where it fails in test_sending_from_reused_address_fails.
         '''
         self.log.info("Test sending from reused address with avoid_reuse=false")
@@ -175,9 +175,9 @@ class AvoidReuseTest(DigiByteTestFramework):
         self.nodes[0].sendtoaddress(fundaddr, 10)
         self.generate(self.nodes[0], 1)
 
-        # listunspent should show 1 single, unused 10 btc output
+        # listunspent should show 1 single, unused 10 dgb output
         assert_unspent(self.nodes[1], total_count=1, total_sum=10, reused_supported=True, reused_count=0)
-        # getbalances should show no used, 10 btc trusted
+        # getbalances should show no used, 10 dgb trusted
         assert_balances(self.nodes[1], mine={"used": 0, "trusted": 10})
         # node 0 should not show a used entry, as it does not enable avoid_reuse
         assert("used" not in self.nodes[0].getbalances()["mine"])
@@ -185,38 +185,38 @@ class AvoidReuseTest(DigiByteTestFramework):
         self.nodes[1].sendtoaddress(retaddr, 5)
         self.generate(self.nodes[0], 1)
 
-        # listunspent should show 1 single, unused ~4.9 btc output
+        # listunspent should show 1 single, unused ~4.9 dgb output
         assert_unspent(self.nodes[1], total_count=1, total_sum=4.9, reused_supported=True, reused_count=0, margin=0.1)
-        # getbalances should show no used, ~4.9 btc trusted
+        # getbalances should show no used, ~4.9 dgb trusted
         assert_balances(self.nodes[1], mine={"used": 0, "trusted": 4.9}, margin=0.1)
 
         self.nodes[0].sendtoaddress(fundaddr, 10)
         self.generate(self.nodes[0], 1)
 
-        # listunspent should show 2 total outputs (~4.9, 10 btc), one unused (~4.9), one reused (10)
+        # listunspent should show 2 total outputs (~4.9, 10 dgb), one unused (~4.9), one reused (10)
         assert_unspent(self.nodes[1], total_count=2, total_sum=14.9, reused_count=1, reused_sum=10, margin=0.1)
-        # getbalances should show 10 used, ~4.9 btc trusted
+        # getbalances should show 10 used, ~4.9 dgb trusted
         assert_balances(self.nodes[1], mine={"used": 10, "trusted": 4.9}, margin=0.1)
 
         self.nodes[1].sendtoaddress(address=retaddr, amount=10, avoid_reuse=False)
 
-        # listunspent should show 1 total outputs (~4.9 btc), unused
+        # listunspent should show 1 total outputs (~4.9 dgb), unused
         assert_unspent(self.nodes[1], total_count=1, total_sum=4.9, reused_count=0, margin=0.1)
-        # getbalances should show no used, ~4.9 btc trusted
+        # getbalances should show no used, ~4.9 dgb trusted
         assert_balances(self.nodes[1], mine={"used": 0, "trusted": 4.9}, margin=0.1)
 
-        # node 1 should now have about 4.9 btc left (for both cases)
+        # node 1 should now have about 4.9 dgb left (for both cases)
         assert_approx(self.nodes[1].getbalance(), 4.9, 0.1)
         assert_approx(self.nodes[1].getbalance(avoid_reuse=False), 4.9, 0.1)
 
     def test_sending_from_reused_address_fails(self, second_addr_type):
         '''
         Test the simple case where [1] generates a new address A, then
-        [0] sends 10 BTC to A.
-        [1] spends 5 BTC from A. (leaving roughly 5 BTC useable)
-        [0] sends 10 BTC to A again.
-        [1] tries to spend 10 BTC (fails; dirty).
-        [1] tries to spend 4 BTC (succeeds; change address sufficient)
+        [0] sends 10 DGB to A.
+        [1] spends 5 DGB from A. (leaving roughly 5 DGB useable)
+        [0] sends 10 DGB to A again.
+        [1] tries to spend 10 DGB (fails; dirty).
+        [1] tries to spend 4 DGB (succeeds; change address sufficient)
         '''
         self.log.info("Test sending from reused {} address fails".format(second_addr_type))
 
@@ -226,17 +226,17 @@ class AvoidReuseTest(DigiByteTestFramework):
         self.nodes[0].sendtoaddress(fundaddr, 10)
         self.generate(self.nodes[0], 1)
 
-        # listunspent should show 1 single, unused 10 btc output
+        # listunspent should show 1 single, unused 10 dgb output
         assert_unspent(self.nodes[1], total_count=1, total_sum=10, reused_supported=True, reused_count=0)
-        # getbalances should show no used, 10 btc trusted
+        # getbalances should show no used, 10 dgb trusted
         assert_balances(self.nodes[1], mine={"used": 0, "trusted": 10})
 
         self.nodes[1].sendtoaddress(retaddr, 5)
         self.generate(self.nodes[0], 1)
 
-        # listunspent should show 1 single, unused ~4.9 btc output
+        # listunspent should show 1 single, unused ~4.9 dgb output
         assert_unspent(self.nodes[1], total_count=1, total_sum=4.9, reused_supported=True, reused_count=0, margin=0.1)
-        # getbalances should show no used, ~4.9 btc trusted
+        # getbalances should show no used, ~4.9 dgb trusted
         assert_balances(self.nodes[1], mine={"used": 0, "trusted": 4.9}, margin=0.1)
 
         if not self.options.descriptors:
@@ -255,9 +255,9 @@ class AvoidReuseTest(DigiByteTestFramework):
             self.nodes[0].sendtoaddress(new_fundaddr, 10)
             self.generate(self.nodes[0], 1)
 
-            # listunspent should show 2 total outputs (~4.9, 10 btc), one unused (~4.9), one reused (10)
+            # listunspent should show 2 total outputs (~4.9, 10 dgb), one unused (~4.9), one reused (10)
             assert_unspent(self.nodes[1], total_count=2, total_sum=14.9, reused_count=1, reused_sum=10, margin=0.1)
-            # getbalances should show 10 used, ~4.9 btc trusted
+            # getbalances should show 10 used, ~4.9 dgb trusted
             assert_balances(self.nodes[1], mine={"used": 10, "trusted": 4.9}, margin=0.1)
 
             # node 1 should now have a balance of ~4.9 (no dirty) or ~14.9 (including dirty)
@@ -268,12 +268,12 @@ class AvoidReuseTest(DigiByteTestFramework):
 
             self.nodes[1].sendtoaddress(retaddr, 4)
 
-            # listunspent should show 2 total outputs (~0.9, 10 btc), one unused (~0.9), one reused (10)
+            # listunspent should show 2 total outputs (~0.9, 10 dgb), one unused (~0.9), one reused (10)
             assert_unspent(self.nodes[1], total_count=2, total_sum=10.9, reused_count=1, reused_sum=10, margin=0.1)
-            # getbalances should show 10 used, ~0.9 btc trusted
+            # getbalances should show 10 used, ~0.9 dgb trusted
             assert_balances(self.nodes[1], mine={"used": 10, "trusted": 0.9}, margin=0.1)
 
-            # node 1 should now have about 0.9 btc left (no dirty) and 10.9 (including dirty)
+            # node 1 should now have about 0.9 dgb left (no dirty) and 10.9 (including dirty)
             assert_approx(self.nodes[1].getbalance(), 0.9, 0.1)
             assert_approx(self.nodes[1].getbalance(avoid_reuse=False), 10.9, 0.1)
 
@@ -308,10 +308,10 @@ class AvoidReuseTest(DigiByteTestFramework):
 
     def test_full_destination_group_is_preferred(self):
         '''
-        Test the case where [1] only has 101 outputs of 1 BTC in the same reused
-        address and tries to send a small payment of 0.5 BTC. The wallet
+        Test the case where [1] only has 101 outputs of 1 DGB in the same reused
+        address and tries to send a small payment of 0.5 DGB. The wallet
         should use 100 outputs from the reused address as inputs and not a
-        single 1 BTC input, in order to join several outputs from the reused
+        single 1 DGB input, in order to join several outputs from the reused
         address.
         '''
         self.log.info("Test that full destination groups are preferred in coin selection")
@@ -322,7 +322,7 @@ class AvoidReuseTest(DigiByteTestFramework):
         new_addr = self.nodes[1].getnewaddress()
         ret_addr = self.nodes[0].getnewaddress()
 
-        # Send 101 outputs of 1 BTC to the same, reused address in the wallet
+        # Send 101 outputs of 1 DGB to the same, reused address in the wallet
         for _ in range(101):
             self.nodes[0].sendtoaddress(new_addr, 1)
 
@@ -338,8 +338,8 @@ class AvoidReuseTest(DigiByteTestFramework):
 
     def test_all_destination_groups_are_used(self):
         '''
-        Test the case where [1] only has 202 outputs of 1 BTC in the same reused
-        address and tries to send a payment of 200.5 BTC. The wallet
+        Test the case where [1] only has 202 outputs of 1 DGB in the same reused
+        address and tries to send a payment of 200.5 DGB. The wallet
         should use all 202 outputs from the reused address as inputs.
         '''
         self.log.info("Test that all destination groups are used")
@@ -350,7 +350,7 @@ class AvoidReuseTest(DigiByteTestFramework):
         new_addr = self.nodes[1].getnewaddress()
         ret_addr = self.nodes[0].getnewaddress()
 
-        # Send 202 outputs of 1 BTC to the same, reused address in the wallet
+        # Send 202 outputs of 1 DGB to the same, reused address in the wallet
         for _ in range(202):
             self.nodes[0].sendtoaddress(new_addr, 1)
 

--- a/test/functional/wallet_balance.py
+++ b/test/functional/wallet_balance.py
@@ -99,7 +99,7 @@ class WalletTest(DigiByteTestFramework):
             assert_equal(self.nodes[0].getbalance("*", 1, True), 72000)
         assert_equal(self.nodes[1].getbalance(minconf=0, include_watchonly=True), 72000)
 
-        # Send 40 BTC from 0 to 1 and 60 BTC from 1 to 0.
+        # Send 40 DGB from 0 to 1 and 60 DGB from 1 to 0.
         txs = create_transactions(self.nodes[0], self.nodes[1].getnewaddress(), 40, [Decimal('0.01')])
         self.nodes[0].sendrawtransaction(txs[0]['hex'])
         self.nodes[1].sendrawtransaction(txs[0]['hex'])  # sending on both nodes is faster than waiting for propagation
@@ -149,7 +149,7 @@ class WalletTest(DigiByteTestFramework):
         # 2) Sent 10 from node B to node A with fee 0.01
         #
         # Then our node would report a confirmed balance of 40 + 50 - 10 = 80
-        # BTC, which is more than would be available if transaction 1 were
+        # DGB, which is more than would be available if transaction 1 were
         # replaced.
 
         def test_balances(*, fee_node_1=0):

--- a/test/functional/wallet_basic.py
+++ b/test/functional/wallet_basic.py
@@ -55,7 +55,7 @@ class WalletTest(DigiByteTestFramework):
 
 
     # Get newly matured utxo with min_amount
-    # DigiByte specific: COINBASE_MATURITY is set to 8 instead of 100 (in BTC).
+    # DigiByte specific: COINBASE_MATURITY is set to 8 instead of 100 (in DGB).
     # During this test suite, more and more coinbase utxos are maturing.
     # This helper function collects them.
     def get_matured_utxos(self, node_index, utxo_seen_map = None, allow_none_coinbase = False, min_amount = Decimal('72000')):
@@ -188,7 +188,7 @@ class WalletTest(DigiByteTestFramework):
         # Have node1 generate 101 blocks (so node0 can recover the fee)
         self.generate(self.nodes[1], COINBASE_MATURITY_2 + 1, sync_fun=lambda: self.sync_all(self.nodes[0:3]))
 
-        # node0 should end up with 100 btc in block rewards plus fees, but
+        # node0 should end up with 100 dgb in block rewards plus fees, but
         # minus the 21 plus fees sent to node2
         assert_equal(self.nodes[0].getbalance(), 2 * 72000 - 21)
         assert_equal(self.nodes[2].getbalance(), 21)
@@ -261,28 +261,28 @@ class WalletTest(DigiByteTestFramework):
         assert_equal(self.nodes[2].getbalance(), node_2_bal)
         node_0_bal = self.check_fee_amount(self.nodes[0].getbalance(), node_0_bal + Decimal('10'), fee_per_byte, self.get_vsize(self.nodes[2].gettransaction(txid)['hex']))
 
-        self.log.info("Test sendmany with fee_rate param (explicit fee rate in sat/vB)")
-        fee_rate_sat_vb = 10000
-        fee_rate_btc_kvb = fee_rate_sat_vb * 1e3 / 1e8
-        explicit_fee_rate_btc_kvb = Decimal(fee_rate_btc_kvb) / 1000
+        self.log.info("Test sendmany with fee_rate param (explicit fee rate in dbit/vB)")
+        fee_rate_dbit_vb = 10000
+        fee_rate_dgb_kvb = fee_rate_dbit_vb * 1e3 / 1e8
+        explicit_fee_rate_dgb_kvb = Decimal(fee_rate_dgb_kvb) / 1000
 
         # Test passing fee_rate as a string
-        txid = self.nodes[2].sendmany(amounts={address: 10}, fee_rate=str(fee_rate_sat_vb))
+        txid = self.nodes[2].sendmany(amounts={address: 10}, fee_rate=str(fee_rate_dbit_vb))
         self.generate(self.nodes[2], 1, sync_fun=lambda: self.sync_all(self.nodes[0:3]))
 
         balance = self.nodes[2].getbalance()
-        node_2_bal = self.check_fee_amount(balance, node_2_bal - Decimal('10'), explicit_fee_rate_btc_kvb, self.get_vsize(self.nodes[2].gettransaction(txid)['hex']))
+        node_2_bal = self.check_fee_amount(balance, node_2_bal - Decimal('10'), explicit_fee_rate_dgb_kvb, self.get_vsize(self.nodes[2].gettransaction(txid)['hex']))
         assert_equal(balance, node_2_bal)
         node_0_bal += Decimal('10')
         assert_equal(self.nodes[0].getbalance(), node_0_bal)
 
         # Test passing fee_rate as an integer
         amount = Decimal("0.1")
-        txid = self.nodes[2].sendmany(amounts={address: amount}, fee_rate=fee_rate_sat_vb)
+        txid = self.nodes[2].sendmany(amounts={address: amount}, fee_rate=fee_rate_dbit_vb)
         self.generate(self.nodes[2], 1, sync_fun=lambda: self.sync_all(self.nodes[0:3]))
 
         balance = self.nodes[2].getbalance()
-        node_2_bal = self.check_fee_amount(balance, node_2_bal - amount, explicit_fee_rate_btc_kvb, self.get_vsize(self.nodes[2].gettransaction(txid)['hex']))
+        node_2_bal = self.check_fee_amount(balance, node_2_bal - amount, explicit_fee_rate_dgb_kvb, self.get_vsize(self.nodes[2].gettransaction(txid)['hex']))
         assert_equal(balance, node_2_bal)
         node_0_bal += amount
         assert_equal(self.nodes[0].getbalance(), node_0_bal)
@@ -291,12 +291,12 @@ class WalletTest(DigiByteTestFramework):
             assert_raises_rpc_error(-8, "Unknown named parameter key", self.nodes[2].sendtoaddress, address=address, amount=1, fee_rate=1, key=1)
 
         # Test setting explicit fee rate just below the minimum.
-        self.log.info("Test sendmany raises 'fee rate too low' if fee_rate of 100 sat/vB is passed")
-        assert_raises_rpc_error(-6, "Fee rate (100.000 sat/vB) is lower than the minimum fee rate setting (10000.000 sat/vB)",
+        self.log.info("Test sendmany raises 'fee rate too low' if fee_rate of 100 dbit/vB is passed")
+        assert_raises_rpc_error(-6, "Fee rate (100.000 dbit/vB) is lower than the minimum fee rate setting (10000.000 dbit/vB)",
             self.nodes[2].sendmany, amounts={address: 10}, fee_rate=100)
 
         self.log.info("Test sendmany raises if fee_rate of 0 or -1 is passed")
-        assert_raises_rpc_error(-6, "Fee rate (0.000 sat/vB) is lower than the minimum fee rate setting (10000.000 sat/vB)",
+        assert_raises_rpc_error(-6, "Fee rate (0.000 dbit/vB) is lower than the minimum fee rate setting (10000.000 dbit/vB)",
             self.nodes[2].sendmany, amounts={address: 10}, fee_rate=0)
 
         assert_raises_rpc_error(-3, OUT_OF_RANGE, self.nodes[2].sendmany, amounts={address: 10}, fee_rate=-1)
@@ -305,7 +305,7 @@ class WalletTest(DigiByteTestFramework):
         for target, mode in product([-1, 0, 1009], ["economical", "conservative"]):
             assert_raises_rpc_error(-8, "Invalid conf_target, must be between 1 and 1008",  # max value of 1008 per src/policy/fees.h
                 self.nodes[2].sendmany, amounts={address: 1}, conf_target=target, estimate_mode=mode)
-        for target, mode in product([-1, 0], ["btc/kb", "sat/b"]):
+        for target, mode in product([-1, 0], ["dgb/kb", "dbit/b"]):
             assert_raises_rpc_error(-8, 'Invalid estimate_mode parameter, must be one of: "unset", "economical", "conservative"',
                 self.nodes[2].sendmany, amounts={address: 1}, conf_target=target, estimate_mode=mode)
 
@@ -454,16 +454,16 @@ class WalletTest(DigiByteTestFramework):
             self.generate(self.nodes[0], 1, sync_fun=lambda: self.sync_all(self.nodes[0:3]))
 
 
-            self.log.info("Test sendtoaddress with fee_rate param (explicit fee rate in sat/vB)")
+            self.log.info("Test sendtoaddress with fee_rate param (explicit fee rate in dbit/vB)")
             self.get_matured_utxos(2, utxo_seen[2]) # clear
             prebalance = self.nodes[2].getbalance()
             assert prebalance > 2
             address = self.nodes[1].getnewaddress()
             amount = 3
-            fee_rate_sat_vb = 10000
-            fee_rate_btc_kvb = fee_rate_sat_vb * 1e3 / 1e8
+            fee_rate_dbit_vb = 10000
+            fee_rate_dgb_kvb = fee_rate_dbit_vb * 1e3 / 1e8
             # Test passing fee_rate as an integer
-            txid = self.nodes[2].sendtoaddress(address=address, amount=amount, fee_rate=fee_rate_sat_vb)
+            txid = self.nodes[2].sendtoaddress(address=address, amount=amount, fee_rate=fee_rate_dbit_vb)
             tx_size = self.get_vsize(self.nodes[2].gettransaction(txid)['hex'])
             self.generate(self.nodes[0], 1, sync_fun=lambda: self.sync_all(self.nodes[0:3]))
 
@@ -474,15 +474,15 @@ class WalletTest(DigiByteTestFramework):
             postbalance -= sum(utxo['amount'] for utxo in maturedUtxos)
 
             fee = prebalance - postbalance - Decimal(amount)
-            assert_fee_amount(fee, tx_size, Decimal(fee_rate_btc_kvb))
+            assert_fee_amount(fee, tx_size, Decimal(fee_rate_dgb_kvb))
 
             prebalance = self.nodes[2].getbalance()
             amount = Decimal("0.1")
-            fee_rate_sat_vb = 10000
-            fee_rate_btc_kvb = fee_rate_sat_vb * 1e3 / 1e8
+            fee_rate_dbit_vb = 10000
+            fee_rate_dgb_kvb = fee_rate_dbit_vb * 1e3 / 1e8
 
             # Test passing fee_rate as a string
-            txid = self.nodes[2].sendtoaddress(address=address, amount=amount, fee_rate=str(fee_rate_sat_vb))
+            txid = self.nodes[2].sendtoaddress(address=address, amount=amount, fee_rate=str(fee_rate_dbit_vb))
             tx_size = self.get_vsize(self.nodes[2].gettransaction(txid)['hex'])
             self.generate(self.nodes[0], 1, sync_fun=lambda: self.sync_all(self.nodes[0:3]))
 
@@ -495,17 +495,17 @@ class WalletTest(DigiByteTestFramework):
             fee = prebalance - postbalance - amount + maturedValue
             tx_obj = self.nodes[2].gettransaction(txid)
 
-            assert_fee_amount(fee, tx_size, Decimal(fee_rate_btc_kvb))
+            assert_fee_amount(fee, tx_size, Decimal(fee_rate_dgb_kvb))
 
             for key in ["totalFee", "feeRate"]:
                 assert_raises_rpc_error(-8, "Unknown named parameter key", self.nodes[2].sendtoaddress, address=address, amount=1, fee_rate=1, key=1)
 
             # Test setting explicit fee rate just below the minimum.
             self.log.info("Test sendtoaddress raises 'fee rate too low' if fee_rate of 99.999 is passed")
-            assert_raises_rpc_error(-6, "Fee rate (99.999 sat/vB) is lower than the minimum fee rate setting (10000.000 sat/vB)", 
+            assert_raises_rpc_error(-6, "Fee rate (99.999 dbit/vB) is lower than the minimum fee rate setting (10000.000 dbit/vB)", 
                 self.nodes[2].sendtoaddress, address=address, amount=1, fee_rate=99.999)
             self.log.info("Test sendtoaddress raises if fee_rate of 0 or -1 is passed")
-            assert_raises_rpc_error(-6, "Fee rate (0.000 sat/vB) is lower than the minimum fee rate setting (10000.000 sat/vB)",
+            assert_raises_rpc_error(-6, "Fee rate (0.000 dbit/vB) is lower than the minimum fee rate setting (10000.000 dbit/vB)",
                 self.nodes[2].sendtoaddress, address=address, amount=10, fee_rate=0)
             assert_raises_rpc_error(-3, OUT_OF_RANGE, self.nodes[2].sendtoaddress, address=address, amount=1.0, fee_rate=-1)
 
@@ -513,7 +513,7 @@ class WalletTest(DigiByteTestFramework):
             for target, mode in product([-1, 0, 1009], ["economical", "conservative"]):
                 assert_raises_rpc_error(-8, "Invalid conf_target, must be between 1 and 1008",  # max value of 1008 per src/policy/fees.h
                     self.nodes[2].sendtoaddress, address=address, amount=1, conf_target=target, estimate_mode=mode)
-            for target, mode in product([-1, 0], ["btc/kb", "sat/b"]):
+            for target, mode in product([-1, 0], ["dgb/kb", "dbit/b"]):
                 assert_raises_rpc_error(-8, 'Invalid estimate_mode parameter, must be one of: "unset", "economical", "conservative"',
                     self.nodes[2].sendtoaddress, address=address, amount=1, conf_target=target, estimate_mode=mode)
 

--- a/test/functional/wallet_bumpfee.py
+++ b/test/functional/wallet_bumpfee.py
@@ -37,7 +37,7 @@ from test_framework.util import (
 WALLET_PASSPHRASE = "test"
 WALLET_PASSPHRASE_TIMEOUT = 3600
 
-# Fee rates (sat/vB)
+# Fee rates (dbit/vB)
 INSUFFICIENT =       1
 ECONOMICAL   =    1500000
 NORMAL       =    6500000
@@ -73,7 +73,7 @@ class BumpFeeTest(DigiByteTestFramework):
         peer_node, rbf_node = self.nodes
         rbf_node_address = rbf_node.getnewaddress()
 
-        # fund rbf node with 10 coins of 0.001 btc (100,000 satoshis)
+        # fund rbf node with 10 coins of 0.001 dgb (100,000 digibits)
         self.log.info("Mining blocks...")
         self.generate(peer_node, COINBASE_MATURITY_2 + 10)
         self.sync_all()
@@ -130,7 +130,7 @@ class BumpFeeTest(DigiByteTestFramework):
         # Test fee_rate values that don't pass fixed-point parsing checks.
         for invalid_value in ["", 0.000000001, 1e-09, 1.111111111, 1111111111111111, "31.999999999999999999999"]:
             assert_raises_rpc_error(-3, msg, rbf_node.bumpfee, rbfid, {"fee_rate": invalid_value})
-        # Test fee_rate values that cannot be represented in sat/vB.
+        # Test fee_rate values that cannot be represented in dbit/vB.
         for invalid_value in [0.0001, 0.00000001, 0.00099999, 31.99999999, "0.0001", "0.00000001", "0.00099999", "31.99999999"]:
             assert_raises_rpc_error(-3, msg, rbf_node.bumpfee, rbfid, {"fee_rate": invalid_value})
         # Test fee_rate out of range (negative number).
@@ -156,7 +156,7 @@ class BumpFeeTest(DigiByteTestFramework):
         for k, v in {"number": 42, "object": {"foo": "bar"}}.items():
             assert_raises_rpc_error(-3, "Expected type string for estimate_mode, got {}".format(k),
                 rbf_node.bumpfee, rbfid, {"estimate_mode": v})
-        for mode in ["foo", Decimal("3.1415"), "sat/B", "BTC/kB"]:
+        for mode in ["foo", Decimal("3.1415"), "dbit/B", "DGB/kB"]:
             assert_raises_rpc_error(-8, 'Invalid estimate_mode parameter, must be one of: "unset", "economical", "conservative"',
                 rbf_node.bumpfee, rbfid, {"estimate_mode": mode})
 
@@ -323,10 +323,10 @@ def test_dust_to_fee(self, rbf_node, dest_address):
     # boundary. Thus expected transaction size (p2wpkh, 1 input, 2 outputs) is 140-141 vbytes, usually 141.
     if not 140 <= fulltx["vsize"] <= 141:
         raise AssertionError("Invalid tx vsize of {} (140-141 expected), full tx: {}".format(fulltx["vsize"], fulltx))
-    # Bump with fee_rate of 350.25 sat/vB vbytes to create dust.
-    # Expected fee is 141 vbytes * fee_rate 0.00350250 BTC / 1000 vbytes = 0.00049385 BTC.
-    # or occasionally 140 vbytes * fee_rate 0.00350250 BTC / 1000 vbytes = 0.00049035 BTC.
-    # Dust should be dropped to the fee, so actual bump fee is 0.00050000 BTC.
+    # Bump with fee_rate of 350.25 dbit/vB vbytes to create dust.
+    # Expected fee is 141 vbytes * fee_rate 0.00350250 DGB / 1000 vbytes = 0.00049385 DGB.
+    # or occasionally 140 vbytes * fee_rate 0.00350250 DGB / 1000 vbytes = 0.00049035 DGB.
+    # Dust should be dropped to the fee, so actual bump fee is 0.00050000 DGB.
     bumped_tx = rbf_node.bumpfee(rbfid, {"fee_rate": 8546090}) #0,03546 0,03571428571
     full_bumped_tx = rbf_node.getrawtransaction(bumped_tx["txid"], 1)
     assert_equal(bumped_tx["fee"], Decimal("17.99550000"))
@@ -363,7 +363,7 @@ def test_settxfee(self, rbf_node, dest_address):
 def test_maxtxfee_fails(self, rbf_node, dest_address):
     self.log.info('Test that bumpfee fails when it hits -maxtxfee')
     # size of bumped transaction (p2wpkh, 1 input, 2 outputs): 141 vbytes
-    # expected bump fee of 141 vbytes * 0.00200000 BTC / 1000 vbytes = 0.00002820 BTC
+    # expected bump fee of 141 vbytes * 0.00200000 DGB / 1000 vbytes = 0.00002820 DGB
     # which exceeds maxtxfee and is expected to raise
     self.restart_node(1, ['-maxtxfee=0.000025'] + self.extra_args[1])
     rbf_node.walletpassphrase(WALLET_PASSPHRASE, WALLET_PASSPHRASE_TIMEOUT)

--- a/test/functional/wallet_groups.py
+++ b/test/functional/wallet_groups.py
@@ -87,7 +87,7 @@ class WalletGroupTest(DigiByteTestFramework):
         # - D ~0.3
         assert_approx(self.nodes[1].getbalance(), vexp=4.3, vspan=0.1)
         assert_approx(self.nodes[2].getbalance(), vexp=4.3, vspan=0.1)
-        # Sending 1.4 btc should pick one 1.0 + one more. For node #1,
+        # Sending 1.4 dgb should pick one 1.0 + one more. For node #1,
         # this could be (A / B0 / C0) + (B1 / C1 / D). We ensure that it is
         # B0 + B1 or C0 + C1, because this avoids partial spends while not being
         # detrimental to transaction cost
@@ -144,7 +144,7 @@ class WalletGroupTest(DigiByteTestFramework):
         assert_equal(2, len(tx5["vout"]))
 
         # Test wallet option maxapsfee with node 4, which sets maxapsfee
-        # 1 sat higher, crossing the threshold from non-grouped to grouped.
+        # 1 dbit higher, crossing the threshold from non-grouped to grouped.
         self.log.info("Test wallet option maxapsfee threshold from non-grouped to grouped")
         addr_aps3 = self.nodes[4].getnewaddress()
         [self.nodes[0].sendtoaddress(addr_aps3, 1.0) for _ in range(5)]

--- a/test/functional/wallet_listsinceblock.py
+++ b/test/functional/wallet_listsinceblock.py
@@ -174,8 +174,8 @@ class ListSinceBlockTest(DigiByteTestFramework):
 
         Problematic case:
 
-        1. User 1 receives BTC in tx1 from utxo1 in block aa1.
-        2. User 2 receives BTC in tx2 from utxo1 (same) in block bb1
+        1. User 1 receives DGB in tx1 from utxo1 in block aa1.
+        2. User 2 receives DGB in tx2 from utxo1 (same) in block bb1
         3. User 1 sees 2 confirmations at block aa3.
         4. Reorg into bb chain.
         5. User 1 asks `listsinceblock aa3` and does not see that tx1 is now

--- a/test/functional/wallet_send.py
+++ b/test/functional/wallet_send.py
@@ -27,7 +27,7 @@ class WalletSendTest(DigiByteTestFramework):
             ["-whitelist=127.0.0.1","-walletrbf=1"],
             ["-whitelist=127.0.0.1","-walletrbf=1"],
         ]
-        getcontext().prec = 8 # Satoshi precision for Decimal
+        getcontext().prec = 8 # Digibit precision for Decimal
 
     def skip_test_if_missing_module(self):
         self.skip_if_no_wallet()
@@ -339,7 +339,7 @@ class WalletSendTest(DigiByteTestFramework):
         self.test_send(from_wallet=w0, to_wallet=w1, amount=1, arg_fee_rate=10000, fee_rate=10000, add_to_wallet=False,
                        expect_error=(-8, "Pass the fee_rate either as an argument, or in the options object, but not both"))
 
-        assert_raises_rpc_error(-8, "Use fee_rate (sat/vB) instead of feeRate", w0.send, {w1.getnewaddress(): 1}, 6, "conservative", 1, {"feeRate": 1.00})
+        assert_raises_rpc_error(-8, "Use fee_rate (dbit/vB) instead of feeRate", w0.send, {w1.getnewaddress(): 1}, 6, "conservative", 1, {"feeRate": 1.00})
 
         assert_raises_rpc_error(-3, "Unexpected key totalFee", w0.send, {w1.getnewaddress(): 1}, 6, "conservative", 1, {"totalFee": 1.00})
 
@@ -347,7 +347,7 @@ class WalletSendTest(DigiByteTestFramework):
             self.test_send(from_wallet=w0, to_wallet=w1, amount=1, conf_target=target, estimate_mode=mode,
                 expect_error=(-8, "Invalid conf_target, must be between 1 and 1008"))  # max value of 1008 per src/policy/fees.h
         msg = 'Invalid estimate_mode parameter, must be one of: "unset", "economical", "conservative"'
-        for target, mode in product([-1, 0], ["btc/kb", "sat/b"]):
+        for target, mode in product([-1, 0], ["dgb/kb", "dbit/b"]):
             self.test_send(from_wallet=w0, to_wallet=w1, amount=1, conf_target=target, estimate_mode=mode, expect_error=(-8, msg))
         for mode in ["", "foo", Decimal("3.141592")]:
             self.test_send(from_wallet=w0, to_wallet=w1, amount=1, conf_target=0.1, estimate_mode=mode, expect_error=(-8, msg))
@@ -359,15 +359,15 @@ class WalletSendTest(DigiByteTestFramework):
                 self.test_send(from_wallet=w0, to_wallet=w1, amount=1, conf_target=v, estimate_mode=mode,
                     expect_error=(-3, f"Expected type number for conf_target, got {k}"))
 
-        # Test setting explicit fee rate just below the minimum of 1 sat/vB.
+        # Test setting explicit fee rate just below the minimum of 1 dbit/vB.
         self.log.info("Explicit fee rate raises RPC error 'fee rate too low' if fee_rate of 99.999999 is passed")
-        msg = "Fee rate (9999.900 sat/vB) is lower than the minimum fee rate setting (10000.000 sat/vB)"
+        msg = "Fee rate (9999.900 dbit/vB) is lower than the minimum fee rate setting (10000.000 dbit/vB)"
         self.test_send(from_wallet=w0, to_wallet=w1, amount=1, fee_rate=9999.9, expect_error=(-4, msg))
         self.test_send(from_wallet=w0, to_wallet=w1, amount=1, arg_fee_rate=9999.9, expect_error=(-4, msg))
 
         self.log.info("Explicit fee rate raises if invalid fee_rate is passed")
         # Test fee_rate with zero values.
-        msg = "Fee rate (0.000 sat/vB) is lower than the minimum fee rate setting (10000.000 sat/vB)"
+        msg = "Fee rate (0.000 dbit/vB) is lower than the minimum fee rate setting (10000.000 dbit/vB)"
         for zero_value in [0, 0.000, 0.00000000, "0", "0.000", "0.00000000"]:
             self.test_send(from_wallet=w0, to_wallet=w1, amount=1, fee_rate=zero_value, expect_error=(-4, msg))
             self.test_send(from_wallet=w0, to_wallet=w1, amount=1, arg_fee_rate=zero_value, expect_error=(-4, msg))
@@ -376,7 +376,7 @@ class WalletSendTest(DigiByteTestFramework):
         for invalid_value in ["", 0.000000001, 1e-09, 1.111111111, 1111111111111111, "31.999999999999999999999"]:
             self.test_send(from_wallet=w0, to_wallet=w1, amount=1, fee_rate=invalid_value, expect_error=(-3, msg))
             self.test_send(from_wallet=w0, to_wallet=w1, amount=1, arg_fee_rate=invalid_value, expect_error=(-3, msg))
-        # Test fee_rate values that cannot be represented in sat/vB.
+        # Test fee_rate values that cannot be represented in dbit/vB.
         for invalid_value in [0.0001, 0.00000001, 0.00099999, 31.99999999, "0.0001", "0.00000001", "0.00099999", "31.99999999"]:
             self.test_send(from_wallet=w0, to_wallet=w1, amount=1, fee_rate=invalid_value, expect_error=(-3, msg))
             self.test_send(from_wallet=w0, to_wallet=w1, amount=1, arg_fee_rate=invalid_value, expect_error=(-3, msg))
@@ -391,7 +391,7 @@ class WalletSendTest(DigiByteTestFramework):
             self.test_send(from_wallet=w0, to_wallet=w1, amount=1, arg_fee_rate=invalid_value, expect_error=(-3, msg))
 
         # TODO: Return hex if fee rate is below -maxmempool
-        # res = self.test_send(from_wallet=w0, to_wallet=w1, amount=1, conf_target=0.1, estimate_mode="sat/b", add_to_wallet=False)
+        # res = self.test_send(from_wallet=w0, to_wallet=w1, amount=1, conf_target=0.1, estimate_mode="dbit/b", add_to_wallet=False)
         # assert res["hex"]
         # hex = res["hex"]
         # res = self.nodes[0].testmempoolaccept([hex])

--- a/test/functional/wallet_txn_clone.py
+++ b/test/functional/wallet_txn_clone.py
@@ -108,7 +108,7 @@ class TxnMallTest(DigiByteTestFramework):
         tx1 = self.nodes[0].gettransaction(txid1)
         tx2 = self.nodes[0].gettransaction(txid2)
 
-        # Node0's balance should be starting balance, plus 50BTC for another
+        # Node0's balance should be starting balance, plus 50DGB for another
         # matured block, minus tx1 and tx2 amounts, and minus transaction fees:
         expected += tx1["amount"] + tx1["fee"]
         expected += tx2["amount"] + tx2["fee"]

--- a/test/functional/wallet_txn_doublespend.py
+++ b/test/functional/wallet_txn_doublespend.py
@@ -73,7 +73,7 @@ class TxnMallTest(DigiByteTestFramework):
         # Coins are sent to node1_address
         node1_address = self.nodes[1].getnewaddress()
 
-        # First: use raw transaction API to send 1240 BTC to node1_address,
+        # First: use raw transaction API to send 1240 DGB to node1_address,
         # but don't broadcast:
         doublespend_fee = Decimal('-.2')
         rawtx_input_0 = {}
@@ -102,7 +102,7 @@ class TxnMallTest(DigiByteTestFramework):
         tx1 = self.nodes[0].gettransaction(txid1)
         tx2 = self.nodes[0].gettransaction(txid2)
 
-        # Node0's balance should be starting balance, plus 50BTC for another
+        # Node0's balance should be starting balance, plus 50DGB for another
         # matured block, minus 40, minus 20, and minus transaction fees:
         expected = starting_balance + fund_foo_tx["fee"] + fund_bar_tx["fee"]
         if self.options.mine_block:

--- a/test/functional/wallet_watchonly.py
+++ b/test/functional/wallet_watchonly.py
@@ -36,10 +36,10 @@ class CreateWalletWatchonlyTest(DigiByteTestFramework):
         wo_wallet.importpubkey(pubkey=def_wallet.getaddressinfo(wo_addr)['pubkey'])
         wo_wallet.importpubkey(pubkey=def_wallet.getaddressinfo(wo_change)['pubkey'])
 
-        # generate some btc for testing
+        # generate some dgb for testing
         self.generatetoaddress(node, COINBASE_MATURITY_2 + 1, a1)
 
-        # send 1 btc to our watch-only address
+        # send 1 dgb to our watch-only address
         txid = def_wallet.sendtoaddress(wo_addr, 1)
         self.generate(self.nodes[0], 1)
 


### PR DESCRIPTION
I have done my best. For situations where the word 'satoshi' was used verbatim in the translated language, I have been able to simply replace it with 'digibit' but there remain several languages that have their own translation of 'satoshi', and so I have not been able to do so. 

In short, to ensure an accurate translation they would need to be reviewed by a native speakers for each language.