### PR TITLE
Rename Satoshi to DigiSatoshi in QT

### DIFF
--- a/src/qt/digibyteunits.cpp
+++ b/src/qt/digibyteunits.cpp
@@ -48,7 +48,7 @@ QString DigiByteUnits::longName(int unit)
     case DGB: return QString("DGB");
     case mDGB: return QString("mDGB");
     case uDGB: return QString::fromUtf8("µDGB (bits)");
-    case SAT: return QString("Satoshi (sat)");
+    case SAT: return QString("DigiSatoshi (sat)");
     default: return QString("???");
     }
 }
@@ -70,7 +70,7 @@ QString DigiByteUnits::description(int unit)
     case DGB: return QString("DigiBytes");
     case mDGB: return QString("Milli-DigiBytes (1 / 1" THIN_SP_UTF8 "000)");
     case uDGB: return QString("Micro-DigiBytes (bits) (1 / 1" THIN_SP_UTF8 "000" THIN_SP_UTF8 "000)");
-    case SAT: return QString("Satoshi (sat) (1 / 100" THIN_SP_UTF8 "000" THIN_SP_UTF8 "000)");
+    case SAT: return QString("DigiSatoshi (sat) (1 / 100" THIN_SP_UTF8 "000" THIN_SP_UTF8 "000)");
     default: return QString("???");
     }
 }

--- a/src/qt/digibyteunits.cpp
+++ b/src/qt/digibyteunits.cpp
@@ -3,6 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+// Source: https://dgbwiki.com/index.php?title=DigiByte#Subunits
+
 #include <qt/digibyteunits.h>
 
 #include <QStringList>

--- a/src/qt/digibyteunits.h
+++ b/src/qt/digibyteunits.h
@@ -37,7 +37,7 @@ public:
     explicit DigiByteUnits(QObject *parent);
 
     /** DigiByte units.
-      @note Source: https://en.digibyte.it/wiki/Units . Please add only sensible ones
+      @note Source: https://dgbwiki.com/index.php?title=DigiByte#Subunits . Please add only sensible ones
      */
     enum Unit
     {

--- a/src/qt/digibyteunits.h
+++ b/src/qt/digibyteunits.h
@@ -68,7 +68,7 @@ public:
     static QString shortName(int unit);
     //! Longer description
     static QString description(int unit);
-    //! Number of Satoshis (1e-8) per unit
+    //! Number of DigiSatoshis (1e-8) per unit
     static qint64 factor(int unit);
     //! Number of decimals left
     static int decimals(int unit);
@@ -104,7 +104,7 @@ public:
         return text;
     }
 
-    //! Return maximum number of base units (Satoshis)
+    //! Return maximum number of base units (DigiSatoshis)
     static CAmount maxMoney();
 
 private:


### PR DESCRIPTION
Clearly renaming it to a DigiBit was proving controversial. This change now makes it match the current "official" name in the DgbWiki: https://dgbwiki.com/index.php?title=DigiByte#Subunits

I elected to leave the abbreviation as 'sat' rather than 'dSat' for now. I think we should either update the wiki to use the abbreviation 'sat', or update DigiByte Core to use dSat in another PR. That way the term is consistent.