### PR TITLE
Allow multiple DigiAssets to same address

### DIFF
--- a/src/rpc/rawtransaction_util.cpp
+++ b/src/rpc/rawtransaction_util.cpp
@@ -118,13 +118,13 @@ CMutableTransaction ConstructTransaction(const UniValue& inputs_in, const UniVal
                 throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, std::string("Invalid DigiByte address: ") + name_);
             }
 
-            if (!destinations.insert(destination).second) {
-                throw JSONRPCError(RPC_INVALID_PARAMETER, std::string("Invalid parameter, duplicated address: ") + name_);
-            }
-
             CScript scriptPubKey = GetScriptForDestination(destination);
             CAmount nAmount = AmountFromValue(outputs[name_]);
 
+            if ((nAmount!=600) && (!destinations.insert(destination).second)) { //if not a DigiAsset only allow 1 output per asset
+                throw JSONRPCError(RPC_INVALID_PARAMETER, std::string("Invalid parameter, duplicated address: ") + name_);
+            }
+            
             CTxOut out(nAmount, scriptPubKey);
             rawTx.vout.push_back(out);
         }

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -380,13 +380,14 @@ void ParseRecipients(const UniValue& address_amounts, const UniValue& subtract_f
             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, std::string("Invalid DigiByte address: ") + address);
         }
 
-        if (destinations.count(dest)) {
-            throw JSONRPCError(RPC_INVALID_PARAMETER, std::string("Invalid parameter, duplicated address: ") + address);
-        }
-        destinations.insert(dest);
-
         CScript script_pub_key = GetScriptForDestination(dest);
         CAmount amount = AmountFromValue(address_amounts[i++]);
+
+        if (destinations.count(dest)) { 
+            throw JSONRPCError(RPC_INVALID_PARAMETER, std::string("Invalid parameter, duplicated address: ") + address);
+        }
+        if (amount!=600) //allow DigiAssets to bypass the 1 output per address limit
+            destinations.insert(dest);
 
         bool subtract_fee = false;
         for (unsigned int idx = 0; idx < subtract_fee_outputs.size(); idx++) {

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -380,14 +380,13 @@ void ParseRecipients(const UniValue& address_amounts, const UniValue& subtract_f
             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, std::string("Invalid DigiByte address: ") + address);
         }
 
-        CScript script_pub_key = GetScriptForDestination(dest);
-        CAmount amount = AmountFromValue(address_amounts[i++]);
-
-        if (destinations.count(dest)) { 
+        if (destinations.count(dest)) {
             throw JSONRPCError(RPC_INVALID_PARAMETER, std::string("Invalid parameter, duplicated address: ") + address);
         }
-        if (amount!=600) //allow DigiAssets to bypass the 1 output per address limit
-            destinations.insert(dest);
+        destinations.insert(dest);
+        
+        CScript script_pub_key = GetScriptForDestination(dest);
+        CAmount amount = AmountFromValue(address_amounts[i++]);
 
         bool subtract_fee = false;
         for (unsigned int idx = 0; idx < subtract_fee_outputs.size(); idx++) {

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -384,7 +384,7 @@ void ParseRecipients(const UniValue& address_amounts, const UniValue& subtract_f
             throw JSONRPCError(RPC_INVALID_PARAMETER, std::string("Invalid parameter, duplicated address: ") + address);
         }
         destinations.insert(dest);
-        
+
         CScript script_pub_key = GetScriptForDestination(dest);
         CAmount amount = AmountFromValue(address_amounts[i++]);
 


### PR DESCRIPTION
There is no reason that multiple outputs can't be sent to the same address other then there where few reasons to do it.   I propose for DigiAssets we allow many outputs to the same address so each can have a different asset.

Yes I do realise this only works if the assets are added first.  Will still throw an error if funds are added then try to add an asset.  This is acceptable limitation.
