### PR TITLE
Activate Taproot

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -107,8 +107,8 @@ public:
 
         // Deployment of Taproot (BIPs 340-342)
         consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].bit = 2;
-        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].nStartTime = 4070908800; // January 1st, 2099
-        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].nTimeout = 4099766400; // December 1st, 2099
+        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].nStartTime = 1722514104; // 1st August 2024
+        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].nTimeout = 1785586104; // 1st August 2026
         consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].min_activation_height = 0; // No activation delay
 
         // The best chain should have at least this much work.
@@ -370,8 +370,8 @@ public:
 
         // Deployment of Taproot (BIPs 340-342)
         consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].bit = 2;
-        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].nStartTime = 4070908800; // January 1st, 2099
-        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].nTimeout = 4099766400; // December 1st, 2099
+        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].nStartTime = 1718921304; // 20th June 2024 Testnet
+        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].nTimeout = 1750457304; // 20th June 2025 Testnet
         consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].min_activation_height = 0; // No activation delay
 
         consensus.nOdoShapechangeInterval = 1*24*60*60; // 1 day

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -107,8 +107,8 @@ public:
 
         // Deployment of Taproot (BIPs 340-342)
         consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].bit = 2;
-        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].nStartTime = 1722514104; // 1st August 2024
-        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].nTimeout = 1785586104; // 1st August 2026
+        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].nStartTime = 1736510438; // 10th January 2025
+        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].nTimeout = 1799582438; // 10th January 2027
         consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].min_activation_height = 0; // No activation delay
 
         // The best chain should have at least this much work.

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1569,6 +1569,7 @@ RPCHelpMan getblockchaininfo()
     SoftForkDescPushBack(tip, softforks, consensusParams, Consensus::DEPLOYMENT_SEGWIT);
     SoftForkDescPushBack(tip, softforks, consensusParams, Consensus::DEPLOYMENT_TESTDUMMY);
     SoftForkDescPushBack(tip, softforks, consensusParams, Consensus::DEPLOYMENT_ODO);
+    SoftForkDescPushBack(tip, softforks, consensusParams, Consensus::DEPLOYMENT_TAPROOT);
     obj.pushKV("softforks", softforks);
     obj.pushKV("warnings", GetWarnings(false).original);
     return obj;


### PR DESCRIPTION
I propose to initiate the Taproot activation soft fork on the DigiByte blockchain. I have an innovative application to develop, and I believe DGB is the most suitable blockchain for it. Taproot is essential for building this application.

This pull request will commence the Taproot activation window from 1st August 2024 to 2026. Additionally, it will begin the testnet activation window from 20th June 2024 to 20th June 2025. Seventy percent of miners will need to agree for one week’s worth of blocks for Taproot deployment to be successful at any point.

Taproot will enable the use of Schnorr signatures on DGB, providing highly advanced smart contract capabilities as well as Tapscript functionalities.