### PR TITLE
wallet: Remove unused descriptor checkbox from wallet creation dialog

### DIFF
--- a/src/qt/createwalletdialog.cpp
+++ b/src/qt/createwalletdialog.cpp
@@ -85,16 +85,8 @@ CreateWalletDialog::CreateWalletDialog(QWidget* parent) :
     });
 
 #ifndef USE_SQLITE
-        ui->descriptor_checkbox->setToolTip(tr("Compiled without sqlite support (required for descriptor wallets)"));
-        ui->descriptor_checkbox->setEnabled(false);
-        ui->descriptor_checkbox->setChecked(false);
         ui->external_signer_checkbox->setEnabled(false);
         ui->external_signer_checkbox->setChecked(false);
-#endif
-
-#ifndef USE_BDB
-        ui->descriptor_checkbox->setEnabled(false);
-        ui->descriptor_checkbox->setChecked(true);
 #endif
 
 #ifndef ENABLE_EXTERNAL_SIGNER

--- a/src/qt/forms/createwalletdialog.ui
+++ b/src/qt/forms/createwalletdialog.ui
@@ -142,7 +142,6 @@
   <tabstop>encrypt_wallet_checkbox</tabstop>
   <tabstop>disable_privkeys_checkbox</tabstop>
   <tabstop>blank_wallet_checkbox</tabstop>
-  <tabstop>descriptor_checkbox</tabstop>
   <tabstop>external_signer_checkbox</tabstop>
  </tabstops>
  <resources/>


### PR DESCRIPTION
## Description

This pull request removes the unused descriptor checkbox from the wallet creation dialog.

### Changes

- Removed the unused descriptor checkbox from the wallet creation dialog.

### Justification and Reasoning

This change cleans up the UI by removing an unused element, improving the user experience, and resolving a compilation error due to the missing `descriptor_checkbox` member that was previously deprecated.

### References

- Related PRs:
  - https://github.com/DigiByte-Core/digibyte/pull/213
  - https://github.com/DigiByte-Core/digibyte/pull/227
- Related Issue:
  - https://github.com/DigiByte-Core/digibyte/issues/239#issuecomment-2120851953

### Testing

- Ensure the wallet creation dialog no longer displays the unused descriptor checkbox.

### Additional Notes

Please review the changes and provide feedback. Feel free to comment if any issues or further improvements are needed.

