### PR TITLE
tests, workspace: Add Taproot soft fork status to getblockchaininfo test and VS Code workspace configuration

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -26,5 +26,16 @@
     "cinttypes": "cpp",
     "typeindex": "cpp",
     "ios": "cpp"
-  }
+  },
+  "cmake.ignoreCMakeListsMissing": true,
+  "boost-test-adapter-robaho.tests": [
+    {
+      "testExecutables": [
+        {
+          "glob": "**/*{_test,_test.exe}"
+        }
+      ],
+      "debugConfig": "Test Config"
+    }
+  ],
 }

--- a/digibyte.code-workspace
+++ b/digibyte.code-workspace
@@ -1,0 +1,58 @@
+{
+	"folders": [
+		{
+			"path": "."
+		}
+	],
+	"settings": {
+		"files.associations": {
+			"chrono": "cpp",
+			"initializer_list": "cpp",
+			"cctype": "cpp",
+			"cmath": "cpp",
+			"csignal": "cpp",
+			"cstdarg": "cpp",
+			"cstddef": "cpp",
+			"cstdio": "cpp",
+			"cstdlib": "cpp",
+			"cstring": "cpp",
+			"ctime": "cpp",
+			"cwchar": "cpp",
+			"cwctype": "cpp",
+			"atomic": "cpp",
+			"strstream": "cpp",
+			"condition_variable": "cpp",
+			"cstdint": "cpp",
+			"future": "cpp",
+			"iosfwd": "cpp",
+			"mutex": "cpp",
+			"ratio": "cpp",
+			"system_error": "cpp",
+			"thread": "cpp",
+			"cinttypes": "cpp",
+			"typeindex": "cpp",
+			"ios": "cpp"
+		},
+		"github.copilot.advanced": {
+			"projectDirectories": [
+				".github",
+				"src",
+				"test",
+				"doc",
+				"qa"
+			],
+			"excludeDirectories": [
+				"**/.deps",
+				"**/.libs",
+				"**/.obj"
+			],
+			"excludeFiles": [
+				"*.a",
+				"*.o",
+				"*.Po",
+				"*.pc",
+				"*.log",
+			]
+		}
+	}
+}

--- a/test/functional/rpc_blockchain.py
+++ b/test/functional/rpc_blockchain.py
@@ -151,20 +151,18 @@ class BlockchainTest(DigiByteTestFramework):
                 'type': 'buried',
                 'active': False,
                 'height': 1000000 # due to easypow
-            }
-            #  Taproot code was removed from getblockchaininfo for time being
-   #         'taproot': {
-   #             'type': 'bip9',
-   #             'bip9': {
-   #                 'status': 'active',
-   #                 'start_time': -1,
-   #                 'timeout': 9223372036854775807,
-   #                 'since': 0,
-   #                 'min_activation_height': 0,
-   #             },
-   #             'height': 0,
-   #             'active': True
-   #         }
+            },
+           'taproot': {
+               'type': 'bip9',
+               'bip9': {
+                   'status': 'defined',
+                   'start_time': 4070908800,
+                   'timeout': 4099766400,
+                   'since': 0,
+                   'min_activation_height': 0,
+               },
+               'active': False
+           }
         })
 
     def _test_getchaintxstats(self):


### PR DESCRIPTION
### Purpose
This pull request includes updates to the `getblockchaininfo` test to include the Taproot soft fork status and adds a new Visual Studio Code workspace configuration file to the repository.

### Changes Made
- **Commit 0bda8ecb41f787679f386a52f909f48ff094ae52**: 
  - Added Taproot soft fork details to the expected `softforks` field in the `getblockchaininfo` test.
  - Ensured the test checks for the correct status, start time, timeout, and activation state of the Taproot soft fork.
  - This update ensures that the `getblockchaininfo` RPC call accurately reflects the status of the Taproot soft fork, which is crucial for testing and validation purposes.
  - Refs #244

- **Commit 698a43abe53b04ea79a8a96edcac03726abde40f**: 
  - Added a new `digibyte.code-workspace` file to configure the Visual Studio Code workspace settings for the DigiByte Core project.
  The `digibyte.code-workspace` file includes the project's folder settings, file associations for proper syntax highlighting, and GitHub Copilot advanced settings.
  - This addition aims to improve the development experience for contributors using Visual Studio Code by providing a pre-configured workspace setup.

### Related Issues
Refs #244

### Additional Information
This PR addresses the need for accurate reporting of the Taproot soft fork status in the `getblockchaininfo` RPC call and enhances the development environment for contributors using Visual Studio Code.