### PR TITLE
Uncomment & Re-Enable Taproot & Dandelion Tests

### DIFF
--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -87,7 +87,7 @@ EXTENDED_SCRIPTS = [
 BASE_SCRIPTS = [
     # Scripts that are run by default.
     # Longest test should go first, to favor running tests in parallel
-    #'p2p_dandelion.py', # p2p dandelion anonymous tx test
+    'p2p_dandelion.py', # p2p dandelion anonymous tx test
     'wallet_hd.py --legacy-wallet',
     'wallet_hd.py --descriptors',
     'wallet_backup.py --legacy-wallet',
@@ -112,8 +112,8 @@ BASE_SCRIPTS = [
     'wallet_dump.py --legacy-wallet',
     'wallet_listtransactions.py --legacy-wallet',
     'wallet_listtransactions.py --descriptors',
-    #'feature_taproot.py --previous_release', #Disable until path forward on taproot determined
-    #'feature_taproot.py', #Disable until path forward on taproot determined
+    'feature_taproot.py --previous_release',
+    'feature_taproot.py',
     'rpc_signer.py',
     'wallet_signer.py --descriptors',
     # vv Tests less than 60s vv
@@ -268,7 +268,7 @@ BASE_SCRIPTS = [
     'wallet_send.py --legacy-wallet',
     'wallet_send.py --descriptors',
     'wallet_create_tx.py --descriptors',
-    #'wallet_taproot.py', #Disable until path forward on taproot determined
+    'wallet_taproot.py',
     'p2p_fingerprint.py',
     'feature_uacomment.py',
     'wallet_coinbase_category.py --legacy-wallet',


### PR DESCRIPTION
Re-enable taproot and dandelion tests.

This PR simply re-enables dandelion & taproot tests, it does not fix them. Doing this PR to enable others to help debug quicker before a v8.22 final release.

You can run these tests with:

> test/functional/test_runner.py feature_taproot.py wallet_taproot.py p2p_dandelion.py  
