### PR TITLE
Update RegTest Settings - Taproot Test

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -636,13 +636,15 @@ public:
         consensus.alwaysUpdateDiffChangeTarget = 400; // Block 400,000 MultiShield Hard Fork
         consensus.workComputationChangeTarget = 1430; // Block 1,430,000 DigiSpeed Hard Fork
         consensus.algoSwapChangeTarget = 2000; // Block 9,000,000 Odo PoW Hard Fork
-        consensus.nRuleChangeActivationThreshold = 168; // 70% of 240
-        consensus.nMinerConfirmationWindow = 240; // 1 hour in RegTest
-        consensus.fRbfEnabled = false;
 
+        // Soft fork Threshhold Regtest
+        consensus.nRuleChangeActivationThreshold = 70; // 70% of 100
+        consensus.nMinerConfirmationWindow = 100; // 1 hour in RegTest
+
+
+        consensus.fRbfEnabled = false;
         consensus.nOdoShapechangeInterval = 4; // 1 minute
         consensus.fPowNoRetargeting = true;
-
         consensus.initialTarget[ALGO_ODO] = ArithToUint256(~arith_uint256(0) >> 38); // 4 difficulty
 
         // Old 1% monthly DGB Reward before 15 secon block change
@@ -684,11 +686,11 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
         consensus.vDeployments[Consensus::DEPLOYMENT_TESTDUMMY].min_activation_height = 0; // No activation delay
 
-        // Activation of Taproot (BIPs 340-342)
+        // Configure Taproot Test Deployment
         consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].bit = 2;
-        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].nStartTime = Consensus::BIP9Deployment::ALWAYS_ACTIVE;
+        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].nStartTime = 0; // Start at genesis
         consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].nTimeout = Consensus::BIP9Deployment::NO_TIMEOUT;
-        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].min_activation_height = 0; // No activation delay
+        consensus.vDeployments[Consensus::DEPLOYMENT_TAPROOT].min_activation_height = 10;
 
         consensus.nMinimumChainWork = uint256{};
         consensus.defaultAssumeValid = uint256{};


### PR DESCRIPTION
These settings allowed for me to step through a complete taproot signaling and activation window soft fork process on regtest. The way taproot softwork will work according to BIP 9 is as follows:
https://en.bitcoin.it/wiki/BIP_0009

> With each block and soft fork, we associate a deployment state. The possible states are:
> 
> DEFINED is the first state that each soft fork starts out as. The genesis block is by definition in this state for each deployment.

> STARTED for blocks past the starttime.

> LOCKED_IN for one retarget period after the first retarget period with STARTED blocks of which at least threshold have the associated bit set in nVersion.

> ACTIVE for all blocks after the LOCKED_IN retarget period.

> FAILED for one retarget period past the timeout time, if LOCKED_IN was not reached.

I can 100% confirm our taproot activation will work.  All tests passing for taproot code.

![Screenshot 2025-01-07 at 5 25 07 PM](https://github.com/user-attachments/assets/8a01be1f-98eb-4ac0-9de2-7896e9def192)
![Screenshot 2025-01-07 at 5 26 50 PM](https://github.com/user-attachments/assets/ae969676-93c8-43c1-868a-172528c78345)
![Screenshot 2025-01-07 at 5 27 15 PM](https://github.com/user-attachments/assets/1471494b-2c65-4941-adcf-3f3ca3629448)
![Screenshot 2025-01-07 at 5 27 55 PM](https://github.com/user-attachments/assets/2a350fd8-e511-41ef-a7e8-6abaa38ab863)
![Screenshot 2025-01-07 at 5 35 18 PM](https://github.com/user-attachments/assets/14cf8d0c-34d6-44a6-9ae8-1577c4ac9f59)

There we have it . The taproot activation process: "defined" -> "started" -> "locked_in" -> "active". Successful activation on regtest.

Note:
So the way activation works is on Jan 10th the network will say "started". If 70% of blocks get mined supporting taproot in a rolling 1 week period then it will switch to "locked_in" then 1 week after it will be "active".  This could take weeks or months. We need 70% of miners to agree.

Once active the GUI will not allow users to send taproot txs though. This functionality was not added until BTC v23 when a drop down selection was added.  3 versions after taproot code was introduced and after activated on BTC.

![Screenshot 2025-01-07 at 5 54 02 PM](https://github.com/user-attachments/assets/48235663-0f5a-4334-95a2-5597b07a4a19)

Prior to that taproot tx's on BTC v22 could only be created manually with outside scripts as detailed here: https://www.reddit.com/r/Bitcoin/comments/r37ky5/howto_create_and_use_a_taproot_wallet_on_testnet/

So once DigiByte activates taproot we will need to release another version of DigiByte Core v8.23 that allows users to use taproot addresses in the GUI. 
