### PR TITLE
oracle: fix consensus deadlock from stale attestation timestamps

### DIFF
--- a/src/oracle/bundle_manager.cpp
+++ b/src/oracle/bundle_manager.cpp
@@ -88,6 +88,28 @@ bool OracleBundleManager::AddOracleMessage(const COraclePriceMessage& message)
         }
     }
 
+    // Periodic cleanup of seen message hashes to prevent deadlock.
+    // When the oracle consensus round stalls (e.g., due to rapid block production
+    // or network partition), messages with the same Phase2 hash keep getting
+    // rejected as duplicates, preventing recovery. Clearing the set periodically
+    // allows fresh consensus rounds to form. The 300-second interval is shorter
+    // than any network's epoch length (testnet=750s, mainnet=1500s), ensuring at
+    // least one cleanup per epoch. The pending_messages map (keyed by oracle_id)
+    // provides the authoritative dedup — seen_message_hashes is best-effort P2P
+    // optimization only.
+    {
+        static int64_t last_seen_cleanup = 0;
+        int64_t now_cleanup = GetTime();
+        if (now_cleanup - last_seen_cleanup > 300) {
+            size_t old_size = seen_message_hashes.size();
+            seen_message_hashes.clear();
+            last_seen_cleanup = now_cleanup;
+            if (old_size > 0) {
+                LogPrint(BCLog::DIGIDOLLAR, "Oracle: Periodic cleanup cleared %zu seen message hashes\n", old_size);
+            }
+        }
+    }
+
     // Calculate message hash for duplicate detection.
     // Use Phase2 hash (oracle_id + price + timestamp) for Phase2-signed messages.
     // GetSignatureHash() includes block_height+nonce which are NOT covered by

--- a/src/oracle/node.cpp
+++ b/src/oracle/node.cpp
@@ -360,23 +360,36 @@ void OracleNode::BroadcastCurrentPrice()
         int64_t consensus_timestamp = 0;
 
         if (bm.GetMinOracleCount() > 1 && bm.ComputeConsensusValues(consensus_price, consensus_timestamp)) {
-            // Consensus exists — create attestation over consensus values
-            COraclePriceMessage attestation = CreateConsensusAttestation(consensus_price, consensus_timestamp);
-            if (!attestation.schnorr_sig.empty()) {
-                // Submit as consensus attestation (for block construction)
-                bm.AddConsensusAttestation(attestation);
+            // DEADLOCK PREVENTION: If the consensus timestamp is stale (>5 minutes
+            // old), the consensus round is frozen. All oracles are creating
+            // attestations with the same (price, timestamp) tuple, producing
+            // identical Phase2 hashes that get rejected by the duplicate filter.
+            // Fall through to individual price broadcast with a fresh timestamp
+            // to break the cycle and allow a new consensus round to form.
+            int64_t consensus_age = timestamp - consensus_timestamp;
+            if (consensus_age > 300) {
+                LogPrintf("Oracle: Consensus timestamp is %lld seconds stale, broadcasting individual price to break deadlock\n", consensus_age);
+                // Clear stale state so fresh messages can form a new consensus
+                bm.ClearPendingMessages();
+            } else {
+                // Consensus exists and is fresh — create attestation over consensus values
+                COraclePriceMessage attestation = CreateConsensusAttestation(consensus_price, consensus_timestamp);
+                if (!attestation.schnorr_sig.empty()) {
+                    // Submit as consensus attestation (for block construction)
+                    bm.AddConsensusAttestation(attestation);
 
-                // Also broadcast via P2P so other nodes receive our attestation
-                if (BroadcastPriceMessage(attestation)) {
-                    std::lock_guard<std::mutex> lock(mtx_price);
-                    last_broadcast_price = price;
-                    last_broadcast_timestamp = timestamp;
+                    // Also broadcast via P2P so other nodes receive our attestation
+                    if (BroadcastPriceMessage(attestation)) {
+                        std::lock_guard<std::mutex> lock(mtx_price);
+                        last_broadcast_price = price;
+                        last_broadcast_timestamp = timestamp;
+                    }
+                    return;
                 }
-                return;
             }
         }
 
-        // No consensus yet or Phase 1 — broadcast individual price as before
+        // No consensus yet, Phase 1, or stale consensus — broadcast individual price
         COraclePriceMessage message = CreatePriceMessage(price, timestamp);
         if (BroadcastPriceMessage(message)) {
             std::lock_guard<std::mutex> lock(mtx_price);

--- a/src/rpc/digidollar.cpp
+++ b/src/rpc/digidollar.cpp
@@ -3668,6 +3668,17 @@ static RPCHelpMan stoporacle()
                         oracle->Stop();
                         success = !oracle->IsRunning();
                         status_message = success ? "Oracle stopped successfully" : "Failed to stop oracle";
+
+                        // Clear stale oracle messaging state to break potential deadlocks.
+                        // The seen_message_hashes, pending_messages, and pending_attestations
+                        // can hold stale entries that prevent consensus recovery after restart.
+                        // ClearPendingMessages() resets the duplicate filter, allowing fresh
+                        // messages to be accepted when the oracle is restarted.
+                        if (success) {
+                            OracleBundleManager& bundleManager = OracleBundleManager::GetInstance();
+                            bundleManager.ClearPendingMessages();
+                            status_message += " (messaging state cleared)";
+                        }
                     } else {
                         status_message = "Oracle not found in manager";
                     }


### PR DESCRIPTION
## Summary

Fixes the oracle attestation deadlock where consensus gets permanently stuck at 0 despite all oracles reporting valid prices. Observed on testnet19 — 8/9 oracles reporting ~$0.00445 but `consensus_price_micro_usd: 0` and `last_bundle_height: 0` for 19+ hours.

### Root Cause

When a consensus round stalls, all oracles create attestations with the same frozen `(price, timestamp)` tuple. The Phase2 hash — `H(oracle_id, price, timestamp)` — is identical each cycle, so the duplicate filter in `AddOracleMessage()` permanently rejects it. Since `BroadcastMessage()` calls `AddOracleMessage()` before pushing to P2P, the message never reaches the network. All oracle nodes enter this state simultaneously with no automatic recovery.

The deadlock chain:
1. `pending_messages` contains entries with stale timestamp T
2. `ComputeConsensusValues()` returns `consensus_timestamp = T` (median of stale entries)
3. Oracle creates attestation with `(price, T)` → Phase2 hash H
4. `AddOracleMessage()` finds H in `seen_message_hashes` → rejected as duplicate
5. `BroadcastMessage()` returns false → message never reaches P2P
6. Other oracles in the same state → no fresh data arrives → goto 1

### Three-Part Fix

1. **Stale consensus detection** (`src/oracle/node.cpp`): When consensus timestamp is >5 minutes old, `BroadcastCurrentPrice()` clears stale state and falls through to individual price broadcast with `GetTime()`. Fresh timestamp → different Phase2 hash → passes duplicate filter → propagates to network → new consensus forms.

2. **Periodic seen-hash cleanup** (`src/oracle/bundle_manager.cpp`): Clear `seen_message_hashes` every 300 seconds in `AddOracleMessage()`. Safety net for automatic recovery. The `pending_messages` map (keyed by oracle_id, accepting only newer timestamps) provides authoritative dedup.

3. **State reset on `stoporacle`** (`src/rpc/digidollar.cpp`): `stoporacle` now calls `ClearPendingMessages()` to reset the duplicate filter. Gives operators a manual recovery path.

### Relationship to RC22 `pending_messages.clear()` Fix

The RC22 fix (`f7a4b1d`) removed `pending_messages.clear()` from `AddOracleBundleToBlock()` to prevent messages being drained on every `CreateNewBlock()` call. This fix addresses a different but related deadlock: messages survive template creation but get permanently trapped in the duplicate filter when the consensus timestamp freezes.

## Test plan

- [ ] Verify oracle recovers from stale consensus within 5 minutes (automatic)
- [ ] Verify `stoporacle`/`startoracle` cycle clears state and allows fresh consensus
- [ ] Verify normal oracle operation (fresh consensus) is unaffected by changes
- [ ] Verify periodic seen-hash cleanup doesn't cause duplicate message processing storms
- [ ] Run existing oracle test suite (`oracle_bundle_manager_tests`, `oracle_phase2_tests`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)