### PR TITLE
fix: restore ZMQ ipc:// Unix domain socket support

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1425,17 +1425,37 @@ bool AppInitMain(NodeContext& node, interfaces::BlockAndHeaderTipInfo* tip_info)
         "-rpcbind",
         "-torcontrol",
         "-whitebind",
-        "-zmqpubhashblock",
-        "-zmqpubhashtx",
-        "-zmqpubrawblock",
-        "-zmqpubrawtx",
-        "-zmqpubsequence",
     }) {
         for (const std::string& socket_addr : args.GetArgs(port_option)) {
             std::string host_out;
             uint16_t port_out{0};
             if (!SplitHostPort(socket_addr, port_out, host_out)) {
                 return InitError(InvalidPortErrMsg(port_option, socket_addr));
+            }
+        }
+    }
+
+    // ZMQ options support both TCP (tcp://host:port) and Unix domain sockets
+    // (ipc:///path/to/socket). Skip port validation for ipc:// addresses since
+    // they use filesystem paths, not host:port format. This restores support
+    // that was inadvertently broken when port validation was added.
+    // See: https://github.com/DigiByte-Core/digibyte/issues/340
+    for (const std::string zmq_option : {
+        "-zmqpubhashblock",
+        "-zmqpubhashtx",
+        "-zmqpubrawblock",
+        "-zmqpubrawtx",
+        "-zmqpubsequence",
+    }) {
+        for (const std::string& socket_addr : args.GetArgs(zmq_option)) {
+            // libzmq natively supports ipc:// for Unix domain sockets
+            if (socket_addr.substr(0, 6) == "ipc://") {
+                continue;
+            }
+            std::string host_out;
+            uint16_t port_out{0};
+            if (!SplitHostPort(socket_addr, port_out, host_out)) {
+                return InitError(InvalidPortErrMsg(zmq_option, socket_addr));
             }
         }
     }


### PR DESCRIPTION
## Summary

- Restores ZMQ Unix domain socket (`ipc://`) support that broke in v8.26 during the Bitcoin Core v26.2 merge
- Splits the port validation loop so ZMQ options skip validation for `ipc://` addresses while TCP-only options (`-rpcbind`, `-proxy`, etc.) retain strict validation
- Backward compatible with DigiByte v8.22.2 configurations and existing documentation (`doc/zmq.md:88`)

## Background

Port validation added in the v26.2 merge rejects `ipc://` addresses because `SplitHostPort()` expects `host:port` format. Unix domain sockets use filesystem paths (`ipc:///tmp/dgb.hashblock`), not ports. This causes nodes configured with `zmqpubhashblock=ipc:///tmp/dgb.hashblock` to crash on startup with "Invalid port specified".

Bitcoin Core fixed this in v28.0 (PRs #27375, #27679) using a `unix:` prefix with internal `ipc://` conversion. This PR takes a simpler approach — directly allowing `ipc://` — since DigiByte v8.22.2 already used `ipc://` and `libzmq` natively supports it.

**Targeting `feature/digidollar-v1` for testnet validation, intended for inclusion in v9.26 mainnet release.**

Fixes https://github.com/DigiByte-Core/digibyte/issues/340

## Test plan

- [ ] Verify `zmqpubhashblock=ipc:///tmp/dgb.hashblock` no longer crashes on startup
- [ ] Verify `zmqpubhashblock=tcp://127.0.0.1:212024` still works (TCP validation intact)
- [ ] Verify invalid TCP addresses (e.g. `zmqpubhashblock=tcp://badhost`) are still rejected
- [ ] Verify non-ZMQ options (`-rpcbind`, `-proxy`) still require valid ports

🤖 Generated with [Claude Code](https://claude.com/claude-code)