### PR TITLE
fix: mint UTXO auto-consolidation fails when margin exceeds balance

### DIFF
--- a/src/rpc/digidollar.cpp
+++ b/src/rpc/digidollar.cpp
@@ -983,24 +983,24 @@ RPCHelpMan mintdigidollar()
                 LogPrintf("DigiDollar RPC Mint: UTXO fragmentation detected (%zu UTXOs). Auto-consolidating...\n",
                           availableUtxos.size());
 
-                // Calculate consolidation target: collateral + fees + 10% margin
-                CAmount consolidationTarget = result.collateralRequired +
-                    (result.collateralRequired / 10) + 10000000; // +10% + 0.1 DGB fee buffer
-
-                // Cap at available balance
+                // Check if total balance covers collateral (ignore margin — the
+                // consolidation itself reduces input count, not total value)
                 CAmount totalAvailable = 0;
                 for (const auto& [outpoint, value] : utxoValues) {
                     totalAvailable += value;
                 }
-                if (consolidationTarget > totalAvailable) {
+                // Need collateral + estimated fees (~0.2 DGB buffer)
+                CAmount minRequired = result.collateralRequired + 20000000;
+                if (totalAvailable < minRequired) {
                     throw JSONRPCError(RPC_WALLET_INSUFFICIENT_FUNDS,
-                        strprintf("Insufficient funds for collateral. Need %.2f DGB, have %.2f DGB across %zu small UTXOs.",
+                        strprintf("Insufficient funds for collateral. Need %.2f DGB, have %.2f DGB.",
                                   result.collateralRequired / 100000000.0,
-                                  totalAvailable / 100000000.0,
-                                  availableUtxos.size()));
+                                  totalAvailable / 100000000.0));
                 }
 
-                // Create consolidation transaction using wallet's standard coin selection
+                // Consolidate: send-to-self sweeping as many UTXOs as possible
+                // into one large output. Use subtractfeefromamount so the
+                // consolidation always succeeds regardless of margin.
                 CTxDestination consolidationDest;
                 {
                     LOCK(pwallet->cs_wallet);
@@ -1011,8 +1011,9 @@ RPCHelpMan mintdigidollar()
                     consolidationDest = *op_dest;
                 }
 
+                // Send entire balance to self, fee subtracted from amount
                 wallet::CCoinControl coin_control;
-                wallet::CRecipient recipient{consolidationDest, consolidationTarget, false};
+                wallet::CRecipient recipient{consolidationDest, totalAvailable, /*subtract_fee=*/true};
                 std::vector<wallet::CRecipient> recipients = {recipient};
 
                 auto consolidation_result = wallet::CreateTransaction(*pwallet, recipients, /*change_pos=*/-1, coin_control, /*sign=*/true);
@@ -1030,8 +1031,8 @@ RPCHelpMan mintdigidollar()
                     pwallet->CommitTransaction(consolidation_tx, {}, {});
                 }
 
-                LogPrintf("DigiDollar RPC Mint: Consolidation tx broadcast: %s (%.2f DGB)\n",
-                          consolidation_txid, consolidationTarget / 100000000.0);
+                LogPrintf("DigiDollar RPC Mint: Consolidation tx broadcast: %s (swept %.2f DGB)\n",
+                          consolidation_txid, totalAvailable / 100000000.0);
 
                 // Re-gather UTXOs (now includes unconfirmed consolidation output)
                 availableUtxos.clear();


### PR DESCRIPTION
## Problem

PR #391 introduced UTXO auto-consolidation for `mintdigidollar` to handle wallets with >400 UTXOs (the `MAX_TX_INPUTS` limit in `txbuilder.cpp`). However, the consolidation itself fails in a common scenario, leaving the bug effectively unfixed in RC25.

**Reported by:** @AussieEpic in DigiSwarm — confirmed the bug is still present in RC25 with >400 mining UTXOs.

### Root Cause

The consolidation logic calculates a target amount:

```cpp
CAmount consolidationTarget = result.collateralRequired +
    (result.collateralRequired / 10) + 10000000; // collateral + 10% + 0.1 DGB
```

When the wallet's total balance barely exceeds the collateral requirement, the 10% margin pushes the target above the available balance:

```
Collateral needed:  250,309 DGB
+ 10% margin:        25,030 DGB
+ 0.1 DGB buffer:         0.1 DGB
= Target:           275,339 DGB
Available balance:  274,686 DGB  ← LESS than target!
```

Result: `"Insufficient funds for collateral. Need 250309.79 DGB, have 274686.74 DGB across 499 small UTXOs."` — the wallet clearly has enough DGB, but the margin math rejects it.

### Reproduction

On testnet19 (RC25), oracle wallet with 499 UTXOs:

```
$ digibyte-cli -rpcwallet=utxo-frag-test mintdigidollar 10000 0

error code: -6
error message:
Insufficient funds for collateral. Need 250309.79 DGB, have 274686.74 DGB across 499 small UTXOs.
```

The wallet has 274K DGB across 499 UTXOs. The top 400 UTXOs (the `MAX_TX_INPUTS` limit) sum to only 225K DGB — below the 250K collateral requirement. So `SelectCoins` correctly identifies this as a fragmentation issue and triggers the consolidation path. But the consolidation rejects because `275K target > 274K available`.

### Fix

Replace the fixed-margin target calculation with a **sweep-to-self** approach using `subtractfeefromamount`:

1. **Minimum check**: Only verify that `total balance > collateral + 0.2 DGB` (the actual minimum needed)
2. **Consolidation**: Send entire balance to self with `subtractfeefromamount=true` — the wallet's standard coin selection handles fee calculation, and the sweep always succeeds regardless of margin
3. **Retry**: Re-gather UTXOs (now a single large output) and retry `BuildMintTransaction`

This approach:
- Never fails due to margin math
- Produces one clean UTXO for the retry (optimal for the mint builder)
- Uses the wallet's battle-tested `CreateTransaction` for fee calculation

### Tested

Built from source and tested on testnet19:

```
$ digibyte-cli -rpcwallet=utxo-frag-test mintdigidollar 10000 0

{
  "txid": "dfa98af4...",
  "dd_minted": 10000,
  "dgb_collateral": 250682.55150161,
  "lock_tier": 0,
  "unlock_height": 139025,
  "collateral_ratio": 150,
  "fee_paid": 0.11830000,
  "position_id": "dfa98af4...",
  "consolidation_txid": "a5bf0373...",
  "utxos_consolidated": true
}
```

Same wallet, same UTXOs that failed on RC25 — now auto-consolidates and mints successfully.

### Test Methodology

1. Sent 450 × 500 DGB to `utxo-frag-test` wallet (creating 499 UTXOs, 274K total)
2. Verified top 400 UTXOs sum to 225K (below 250K collateral requirement)
3. Confirmed RC25 binary fails with "Insufficient funds" error
4. Built patched binary from this branch
5. Confirmed patched binary auto-consolidates and mints successfully
6. Restored RC25 binary, verified oracle still running

### Files Changed

- `src/rpc/digidollar.cpp` — consolidation block in `mintdigidollar` handler

## Test plan

- [x] Reproduce failure on RC25 with >400 fragmented UTXOs
- [x] Verify patched binary auto-consolidates and mints successfully
- [x] Verify `consolidation_txid` and `utxos_consolidated` appear in response
- [x] Verify oracle continues running after swap back to RC25
- [ ] Test edge case: wallet with barely enough balance (collateral + 0.3 DGB)
- [ ] Test edge case: wallet with exactly 400 UTXOs (boundary condition)

🤖 Generated with [Claude Code](https://claude.com/claude-code)