### PR TITLE
fix: read system health from stats index in estimatecollateral (Bug #34)

### DIFF
--- a/src/rpc/digidollar.cpp
+++ b/src/rpc/digidollar.cpp
@@ -2567,17 +2567,69 @@ static RPCHelpMan estimatecollateral()
             int lockDays = GetLockDaysForTier(lockTier);
             int baseRatio = GetMinCollateralRatio(lockTier);
 
-            // Get real system health and DCA multiplier from chain state
-            // Previously hardcoded to 150/1.0 — caused wrong collateral
-            // estimates when system health degrades (DCA multiplier increases)
-            DigiDollar::SystemMetrics metrics = DigiDollar::SystemHealthMonitor::GetSystemMetrics();
-            CAmount totalCollateral_est = metrics.totalCollateral;
-            CAmount totalDD_est = metrics.totalDDSupply;
+            // Get real system health and DCA multiplier from chain state.
+            //
+            // Bug #34 fix: previously this called GetSystemMetrics() without
+            // populating the cache first. That static cache (s_currentMetrics)
+            // is only filled when ScanUTXOSet() runs, which only happens inside
+            // getdigidollarstats and getprotectionstatus. If estimatecollateral
+            // ran before either of those, the cache had totalDDSupply=0, and the
+            // check below hardcoded systemHealth to 0 / emergency / DCA 2x —
+            // even when the system was well-collateralized at 528%.
+            //
+            // Fix: read totalCollateral and totalDDSupply from the stats index
+            // (fast, already synced) or fall back to ScanUTXOSet(), matching
+            // the same pattern getdigidollarstats and getprotectionstatus use.
+            CAmount totalCollateral_est = 0;
+            CAmount totalDD_est = 0;
+
+            {
+                const node::NodeContext& node = EnsureAnyNodeContext(request.context);
+                ChainstateManager& chainman = EnsureChainman(node);
+
+                if (g_digidollar_stats_index) {
+                    // Fast path: read from the stats index (already synced)
+                    if (g_digidollar_stats_index->BlockUntilSyncedToCurrentChain()) {
+                        const CBlockIndex* pindex;
+                        {
+                            LOCK(cs_main);
+                            pindex = chainman.ActiveChain().Tip();
+                        }
+                        if (pindex) {
+                            auto stats = g_digidollar_stats_index->LookUpStats(*pindex);
+                            if (stats) {
+                                totalDD_est = stats->total_dd_supply;
+                                totalCollateral_est = stats->total_collateral;
+                            }
+                        }
+                    }
+                } else {
+                    // Slow fallback: scan the UTXO set (same as getdigidollarstats)
+                    Chainstate& active_chainstate = chainman.ActiveChainstate();
+                    active_chainstate.ForceFlushStateToDisk();
+                    {
+                        LOCK(::cs_main);
+                        CCoinsView* coins_view = &active_chainstate.CoinsDB();
+                        node::BlockManager* blockman = &active_chainstate.m_blockman;
+                        const CTxMemPool* mempool = node.mempool.get();
+                        DigiDollar::SystemHealthMonitor::ScanUTXOSet(
+                            coins_view, &active_chainstate.CoinsTip(), blockman, mempool);
+                    }
+                    DigiDollar::SystemMetrics metrics = DigiDollar::SystemHealthMonitor::GetSystemMetrics();
+                    totalCollateral_est = metrics.totalCollateral;
+                    totalDD_est = metrics.totalDDSupply;
+                }
+            }
+
             CAmount oraclePriceMillicents_est = oraclePriceMicroUSD / 10;
 
+            // Calculate system health from real chain data.
+            // When totalDD is 0 (no positions exist), use max health (30000)
+            // so DCA multiplier is 1x — there's nothing at risk, no reason to
+            // penalize the first minter with an emergency multiplier.
             int systemHealth;
             if (totalDD_est == 0) {
-                systemHealth = 0;
+                systemHealth = 30000;
             } else {
                 systemHealth = DynamicCollateralAdjustment::CalculateSystemHealth(
                     totalCollateral_est, totalDD_est, oraclePriceMillicents_est);


### PR DESCRIPTION
## Summary

- **Bug #34**: `estimatecollateral` reports system_health=0 / emergency / DCA=2x when the system is actually healthy at 475-528%. Doubles the reported collateral requirement, blocking valid mints with "Insufficient funds."
- **Root cause**: `estimatecollateral` calls `GetSystemMetrics()` which reads a static cache that is only populated when `ScanUTXOSet()` runs inside `getdigidollarstats` or `getprotectionstatus`. If neither has run, the cache has `totalDDSupply=0`, and line 2579 hardcodes `systemHealth=0`.
- **Fix**: Read `totalCollateral` and `totalDDSupply` from the digidollar stats index (fast path) or fall back to `ScanUTXOSet()` (slow path), matching the pattern `getdigidollarstats` and `getprotectionstatus` already use. Also change the `totalDD==0` fallback from `health=0` to `health=30000` (max) — an empty system has nothing at risk.
- **Single file change**: `src/rpc/digidollar.cpp`
- **Still present in RC29** — RH-36a fixed a different cache race (TOCTOU after restart), not this code path.

## Evidence — same node, same moment

| RPC | Health | DCA | Status |
|-----|--------|-----|--------|
| `getdigidollarstats` | 475% | 1x | healthy |
| `getprotectionstatus` | 475 | 1x | secure |
| **`estimatecollateral`** | **0** | **2x** | **emergency** |

System has 15 active positions, 1.69M DGB locked, 150K cents DD supply.

## Test plan

- [x] Build clean on RC28 tag — no warnings
- [x] Confirmed bug still present on RC29 binary (same `GetSystemMetrics()` code path)
- [x] After fix: `estimatecollateral` returns health=510 / DCA=1x, matching other RPCs
- [x] Tier-4 mint that required 134K DGB (broken) now correctly requires 67K DGB
- [x] Mint succeeds at 67K DGB — previously rejected with "Insufficient funds"
- [x] `getdigidollarstats`, `getprotectionstatus` behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)