### PR TITLE
fix: Qt wallet mint fails on fragmented UTXOs — missing auto-consolidation

### DIFF
--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -27,6 +27,7 @@
 #include <util/translation.h>
 #include <util/strencodings.h> // for strprintf
 #include <wallet/coincontrol.h>
+#include <wallet/spend.h> // for AvailableCoins, CreateTransaction
 #include <wallet/wallet.h> // for CRecipient
 #include <univalue.h>
 #include <wallet/digidollarwallet.h> // for DigiDollarWallet
@@ -922,6 +923,143 @@ WalletModel::DigiDollarMintResult WalletModel::mintDigiDollar(CAmount ddAmount, 
                   ddAmount, lockDays, currentHeight, oraclePrice, availableUtxos.size());
 
         DigiDollar::TxBuilderResult result = builder.BuildMintTransaction(params);
+
+        // Auto-consolidate if mint failed due to UTXO fragmentation
+        // (mirrors the RPC mintdigidollar consolidation logic)
+        std::string consolidation_txid;
+        if (!result.success && result.error.find("Too many small UTXOs") != std::string::npos) {
+            LogPrintf("DigiDollar Qt: UTXO fragmentation detected (%zu UTXOs). Auto-consolidating...\n",
+                      availableUtxos.size());
+
+            CAmount minRequired = result.collateralRequired + 20000000; // collateral + 0.2 DGB margin
+            if (totalAvailable < minRequired) {
+                return DigiDollarMintResult(AmountExceedsBalance, "", "",
+                    QString("Insufficient funds for collateral. Need %1 DGB, have %2 DGB.")
+                        .arg(result.collateralRequired / 100000000.0, 0, 'f', 2)
+                        .arg(totalAvailable / 100000000.0, 0, 'f', 2));
+            }
+
+            CTxDestination consolidationDest;
+            {
+                LOCK(pWallet->cs_wallet);
+                auto op_dest = pWallet->GetNewChangeDestination(OutputType::BECH32);
+                if (!op_dest) {
+                    return DigiDollarMintResult(TransactionCreationFailed, "", "",
+                        "Failed to get consolidation address");
+                }
+                consolidationDest = *op_dest;
+            }
+
+            // Multi-pass consolidation: MAX_STANDARD_TX_WEIGHT is 400k WU.
+            // P2WPKH input ~271 WU. Conservative limit: 1400 inputs per pass.
+            static const size_t MAX_CONSOLIDATION_INPUTS = 1400;
+            static const int MAX_CONSOLIDATION_PASSES = 10;
+            int pass = 0;
+
+            while (availableUtxos.size() > MAX_CONSOLIDATION_INPUTS && pass < MAX_CONSOLIDATION_PASSES) {
+                ++pass;
+                size_t batch_size = std::min(availableUtxos.size(), MAX_CONSOLIDATION_INPUTS);
+                LogPrintf("DigiDollar Qt: Consolidation pass %d — sweeping %zu of %zu UTXOs\n",
+                          pass, batch_size, availableUtxos.size());
+
+                wallet::CCoinControl coin_control;
+                CAmount batchTotal = 0;
+                for (size_t i = 0; i < batch_size; ++i) {
+                    coin_control.Select(availableUtxos[i]);
+                    batchTotal += utxoValues[availableUtxos[i]];
+                }
+                coin_control.m_allow_other_inputs = false;
+
+                wallet::CRecipient recipient{consolidationDest, batchTotal, /*subtract_fee=*/true};
+                std::vector<wallet::CRecipient> recipients = {recipient};
+
+                auto consolidation_result = wallet::CreateTransaction(*pWallet, recipients, /*change_pos=*/-1, coin_control, /*sign=*/true);
+                if (!consolidation_result) {
+                    return DigiDollarMintResult(TransactionCreationFailed, "", "",
+                        QString("Auto-consolidation pass %1 failed: %2")
+                            .arg(pass)
+                            .arg(QString::fromStdString(util::ErrorString(consolidation_result).original)));
+                }
+
+                const CTransactionRef& consolidation_tx = consolidation_result->tx;
+                consolidation_txid = consolidation_tx->GetHash().GetHex();
+                {
+                    LOCK(pWallet->cs_wallet);
+                    pWallet->CommitTransaction(consolidation_tx, {}, {});
+                }
+
+                LogPrintf("DigiDollar Qt: Consolidation pass %d tx: %s (swept %.2f DGB from %zu inputs)\n",
+                          pass, consolidation_txid, batchTotal / 100000000.0, batch_size);
+
+                // Refresh UTXO set after consolidation
+                availableUtxos.clear();
+                utxoValues.clear();
+                totalAvailable = 0;
+                {
+                    LOCK(pWallet->cs_wallet);
+                    wallet::CoinsResult coins = wallet::AvailableCoins(*pWallet);
+                    for (const wallet::COutput& coin : coins.All()) {
+                        availableUtxos.push_back(coin.outpoint);
+                        utxoValues[coin.outpoint] = coin.txout.nValue;
+                        totalAvailable += coin.txout.nValue;
+                    }
+                }
+                LogPrintf("DigiDollar Qt: After pass %d: %zu UTXOs available\n", pass, availableUtxos.size());
+            }
+
+            // Single-pass consolidation for <= 1400 UTXOs
+            if (consolidation_txid.empty() && availableUtxos.size() <= MAX_CONSOLIDATION_INPUTS) {
+                wallet::CCoinControl coin_control;
+                CAmount batchTotal = 0;
+                for (const auto& utxo : availableUtxos) {
+                    coin_control.Select(utxo);
+                    batchTotal += utxoValues[utxo];
+                }
+                coin_control.m_allow_other_inputs = false;
+
+                wallet::CRecipient recipient{consolidationDest, batchTotal, /*subtract_fee=*/true};
+                std::vector<wallet::CRecipient> recipients = {recipient};
+
+                auto consolidation_result = wallet::CreateTransaction(*pWallet, recipients, /*change_pos=*/-1, coin_control, /*sign=*/true);
+                if (!consolidation_result) {
+                    return DigiDollarMintResult(TransactionCreationFailed, "", "",
+                        QString("Auto-consolidation failed: %1")
+                            .arg(QString::fromStdString(util::ErrorString(consolidation_result).original)));
+                }
+
+                const CTransactionRef& consolidation_tx = consolidation_result->tx;
+                consolidation_txid = consolidation_tx->GetHash().GetHex();
+                {
+                    LOCK(pWallet->cs_wallet);
+                    pWallet->CommitTransaction(consolidation_tx, {}, {});
+                }
+
+                LogPrintf("DigiDollar Qt: Single-pass consolidation tx: %s (swept %.2f DGB from %zu inputs)\n",
+                          consolidation_txid, batchTotal / 100000000.0, availableUtxos.size());
+
+                // Refresh UTXO set after consolidation
+                availableUtxos.clear();
+                utxoValues.clear();
+                totalAvailable = 0;
+                {
+                    LOCK(pWallet->cs_wallet);
+                    wallet::CoinsResult coins = wallet::AvailableCoins(*pWallet);
+                    for (const wallet::COutput& coin : coins.All()) {
+                        availableUtxos.push_back(coin.outpoint);
+                        utxoValues[coin.outpoint] = coin.txout.nValue;
+                        totalAvailable += coin.txout.nValue;
+                    }
+                }
+            }
+
+            LogPrintf("DigiDollar Qt: After consolidation: %zu UTXOs available (passes: %d)\n",
+                      availableUtxos.size(), pass);
+
+            // Retry mint with consolidated UTXOs
+            QtMintTxBuilder retryBuilder(Params(), currentHeight, oraclePrice, utxoValues);
+            params.utxos = availableUtxos;
+            result = retryBuilder.BuildMintTransaction(params);
+        }
 
         if (!result.success) {
             LogPrintf("DigiDollar Qt: ERROR - BuildMintTransaction failed: %s\n", result.error);


### PR DESCRIPTION
## Summary

- **Bug:** Qt GUI mints fail with "Too many small UTXOs" when the wallet has many coinbase-sized UTXOs (~1,078 DGB each), because `BuildMintTransaction` enforces a 400-input limit (~431,400 DGB max) and the Qt path had no consolidation fallback
- **Root cause:** PR #391 added UTXO auto-consolidation to the **RPC** `mintdigidollar` handler (`src/rpc/digidollar.cpp:983-1111`) but the **Qt** wallet's `mintDigiDollar` (`src/qt/walletmodel.cpp`) was never updated with the same logic — it called `BuildMintTransaction` once and returned the error directly on failure
- **Fix:** Port the identical multi-pass consolidation logic (1400 inputs/pass, 10 max passes) into the Qt mint path, so GUI users get the same transparent consolidation-then-retry behavior as RPC users

## Reproduction (reported by Aussie and DanGB on RC29 testnet)

| Mint Amount | Collateral Needed | 400-Input Capacity | Result |
|-------------|------------------|--------------------|--------|
| $100 DD (tier 0) | ~231,000 DGB | ~431,400 DGB | **Pass** |
| $200 DD (tier 0) | ~462,000 DGB | ~431,400 DGB | **Fail** |
| $300 DD (tier 0) | ~694,000 DGB | ~431,400 DGB | **Fail** |

DanGB has 11M tDGB across thousands of ~1,078 DGB coinbase UTXOs. Aussie has a similar distribution. Both confirmed $100 works but $200+ fails in Qt. The RPC path would have auto-consolidated and succeeded.

## How it works

1. `BuildMintTransaction` attempts the mint — if it fails with "Too many small UTXOs":
2. Check total balance covers collateral requirement
3. Multi-pass loop: sweep up to 1400 UTXOs per pass into a single consolidation output (wallet change address), broadcast each consolidation tx, refresh the UTXO set
4. Single-pass fallback: if total UTXOs <= 1400, one consolidation tx suffices
5. Retry `BuildMintTransaction` with the consolidated UTXO set

## Test plan

- [ ] Qt wallet mint with >400 small UTXOs now auto-consolidates and succeeds
- [ ] Qt wallet mint with <400 UTXOs still works without consolidation (no regression)
- [ ] RPC `mintdigidollar` behavior unchanged
- [ ] Consolidation tx appears in wallet history
- [ ] Error message shown if total balance truly insufficient after consolidation attempt

🤖 Generated with [Claude Code](https://claude.com/claude-code)