### PR TITLE
fix: chained DD transfers fail — mempool DD input amount resolution (Bug #35)

### DIFF
--- a/src/digidollar/validation.cpp
+++ b/src/digidollar/validation.cpp
@@ -15,6 +15,7 @@ using DigiDollar::GetScriptMetadata;
 #include <consensus/dca.h>
 #include <consensus/err.h>
 #include <index/txindex.h>  // For decentralized DD amount lookup via g_txindex
+#include <txmempool.h>      // For mempool DD amount lookup (Bug #35)
 #include <script/standard.h>
 #include <script/solver.h>
 #include <script/interpreter.h>
@@ -327,6 +328,30 @@ static bool ExtractDDAmountFromTxRef(const CTransactionRef& prev_tx, const COutP
     LogPrint(BCLog::DIGIDOLLAR, "DigiDollar: ExtractDDAmountFromTxRef - output %d not found in tx %s\n",
              prevout.n, prevout.hash.ToString());
     return false;
+}
+
+/**
+ * Extract DD amount from a transaction in the mempool (Bug #35).
+ * Mempool txs have already passed full validation, so their OP_RETURN is trustworthy.
+ * This enables chaining DD transfers without waiting for block confirmation.
+ */
+bool ExtractDDAmountFromMempool(const COutPoint& prevout, const CTxMemPool* mempool, CAmount& amount) {
+    amount = 0;
+    if (!mempool) return false;
+
+    CTransactionRef prev_tx = mempool->get(prevout.hash);
+    if (!prev_tx) {
+        LogPrint(BCLog::DIGIDOLLAR, "DigiDollar: ExtractDDAmountFromMempool - tx %s not in mempool\n",
+                 prevout.hash.ToString());
+        return false;
+    }
+
+    bool ok = ExtractDDAmountFromTxRef(prev_tx, prevout, amount);
+    if (ok) {
+        LogPrint(BCLog::DIGIDOLLAR, "DigiDollar: ExtractDDAmountFromMempool - tx %s vout %d = %lld cents\n",
+                 prevout.hash.ToString(), prevout.n, (long long)amount);
+    }
+    return ok;
 }
 
 bool ExtractDDAmountFromPrevTx(const COutPoint& prevout, CAmount& amount) {
@@ -1255,6 +1280,13 @@ bool ValidateTransferTransaction(const CTransaction& tx,
             CAmount ddAmt = 0;
             bool found = false;
 
+            // 0. Try mempool lookup (for spending unconfirmed DD outputs — Bug #35)
+            if (!found && ctx.mempool) {
+                if (ExtractDDAmountFromMempool(txin.prevout, ctx.mempool, ddAmt) && ddAmt > 0) {
+                    found = true;
+                }
+            }
+
             // 1. Try txindex (authoritative — reads creating tx's OP_RETURN)
             if (!found && ExtractDDAmountFromPrevTx(txin.prevout, ddAmt) && ddAmt > 0) {
                 found = true;
@@ -1388,6 +1420,10 @@ bool ValidateRedemptionTransaction(const CTransaction& tx,
                         if (ExtractDDAmount(coin.out.scriptPubKey, ddAmount) && ddAmount > 0) {
                             totalDDInputs += ddAmount;
                             LogPrint(BCLog::DIGIDOLLAR, "DigiDollar: DD input %d - amount: %lld cents (from registry)\n",
+                                     i, (long long)ddAmount);
+                        } else if (ctx.mempool && ExtractDDAmountFromMempool(input.prevout, ctx.mempool, ddAmount) && ddAmount > 0) {
+                            totalDDInputs += ddAmount;
+                            LogPrint(BCLog::DIGIDOLLAR, "DigiDollar: DD input %d - amount: %lld cents (from mempool)\n",
                                      i, (long long)ddAmount);
                         } else if (ExtractDDAmountFromPrevTx(input.prevout, ddAmount) && ddAmount > 0) {
                             totalDDInputs += ddAmount;

--- a/src/digidollar/validation.h
+++ b/src/digidollar/validation.h
@@ -16,6 +16,8 @@
 #include <chainparams.h>
 #include <coins.h>
 
+class CTxMemPool;
+
 #include <cstdint>
 #include <functional>
 #include <vector>
@@ -68,13 +70,14 @@ struct ValidationContext {
     const CCoinsViewCache* coins;    // Coins view for UTXO lookups (nullptr if not available)
     bool skipOracleValidation;       // Skip oracle-dependent validation (for historical blocks)
     TxLookupFn txLookup;             // Look up tx from block database (for DD amount extraction)
+    const CTxMemPool* mempool;       // Mempool for resolving DD amounts from unconfirmed parent txs
 
     ValidationContext(int height, CAmount price_micro_usd, int collateral, const CChainParams& chainParams,
                       const CCoinsViewCache* coins_view = nullptr, bool skip_oracle = false,
-                      TxLookupFn tx_lookup = nullptr)
+                      TxLookupFn tx_lookup = nullptr, const CTxMemPool* pool = nullptr)
         : nHeight(height), oraclePriceMicroUSD(price_micro_usd), systemCollateral(collateral),
           params(chainParams), coins(coins_view), skipOracleValidation(skip_oracle),
-          txLookup(std::move(tx_lookup)) {}
+          txLookup(std::move(tx_lookup)), mempool(pool) {}
 };
 
 // ============================================================================

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -804,7 +804,8 @@ bool MemPoolAccept::PreChecks(ATMPArgs& args, Workspace& ws)
             args.m_chainparams,                          // Chain parameters
             &m_active_chainstate.CoinsTip(),             // Coins view for UTXO lookup
             false,                                       // Don't skip oracle validation in mempool
-            txLookup                                     // Block-db tx lookup for DD amounts
+            txLookup,                                    // Block-db tx lookup for DD amounts
+            &m_pool                                      // Mempool for unconfirmed DD input lookup
         );
 
         if (!DigiDollar::ValidateDigiDollarTransaction(tx, ddContext, state)) {


### PR DESCRIPTION
## Summary

- **Bug:** Back-to-back DD transfers fail with `transfer-dd-conservation-violation` because the validator can't determine DD amounts from inputs whose creating transaction is still in the mempool
- **Root cause:** All three DD amount lookup strategies in `validation.cpp:1280-1305` fail for unconfirmed parent txs: `txindex` only indexes confirmed blocks, block-db lookup can't find mempool txs, and P2TR scripts don't encode DD amounts. The input's DD amount is silently dropped from the conservation sum.
- **Fix:** Add mempool transaction lookup as strategy 0 (before txindex). `CTxMemPool::get()` retrieves the unconfirmed parent tx, then `ExtractDDAmountFromTxRef()` parses its OP_RETURN — same trustworthy path used for confirmed txs. The mempool pointer is passed via `ValidationContext` from `MemPoolAccept::PreChecks` where it's naturally available.

## Reproduction

```bash
# Send $1 DD — succeeds (confirmed DD input)
digibyte-cli -rpcwallet=oracle senddigidollar "TD1..." 100

# Immediately send $2 DD — FAILS (change UTXO from above is unconfirmed)
digibyte-cli -rpcwallet=oracle senddigidollar "TD1..." 200
# Error: "transfer-dd-conservation-violation, DD not conserved: input=0, output=200"

# Wait for 1 block, retry — succeeds (now txindex/block-db can find it)
```

## Changes

| File | Change |
|------|--------|
| `src/digidollar/validation.h` | Add `const CTxMemPool* mempool` to `ValidationContext`, forward-declare `CTxMemPool` |
| `src/digidollar/validation.cpp` | Add `ExtractDDAmountFromMempool()` helper; insert mempool lookup as strategy 0 in both transfer conservation check and redemption DD input extraction |
| `src/validation.cpp` | Pass `&m_pool` when constructing `ValidationContext` in `MemPoolAccept::PreChecks` |

## Safety

- Mempool txs have already passed full validation (including their own conservation check) before acceptance, so their OP_RETURN data is trustworthy
- `CTxMemPool::get()` takes its own lock (`LOCK(cs)`) — no external lock ordering concerns
- Block validation path passes `nullptr` for mempool (unchanged behavior)
- The mempool lookup is tried first as an optimization — confirmed txs won't be in the mempool, so it returns `false` quickly and falls through to txindex/block-db

## Test plan

- [ ] Chain two DD transfers back-to-back without waiting for a block — second transfer should succeed
- [ ] Chain 5+ transfers rapidly — all should succeed
- [ ] Confirmed DD transfers still work (no regression)
- [ ] Block validation of DD transactions unchanged (mempool=nullptr)
- [ ] Redemption of DD from unconfirmed transfer input works

🤖 Generated with [Claude Code](https://claude.com/claude-code)