### PR TITLE
doc: fix broken Transifex link in README (#371)

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,11 +174,7 @@ not straightforward.
 Translations
 ------------
 
-Changes to translations as well as new translations can be submitted to
-[DigiByte Core's Transifex page](https://www.transifex.com/digibyte/digibyte/).
+For translation contributions and discussions, please join the
+[DigiByte Translations Telegram group](https://t.me/DigiByteTranslations).
 
-Translations are periodically pulled from Transifex and merged into the git repository. See the
-[translation process](doc/translation_process.md) for details on how this works.
-
-**Important**: We do not accept translation changes as GitHub pull requests because the next
-pull from Transifex would automatically overwrite them again.
+See the [translation process](doc/translation_process.md) for details on how this works.


### PR DESCRIPTION
## Summary

Fixes the broken Transifex link reported in #371.

The DigiByte Transifex project at https://www.transifex.com/digibyte/digibyte/ no longer exists and returns a 404 error.

## Changes

Replaced the Transifex section in README.md with a reference to the [DigiByte Translations Telegram group](https://t.me/DigiByteTranslations), which is the active community translation channel.

## Before

> Changes to translations as well as new translations can be submitted to [DigiByte Core's Transifex page](https://www.transifex.com/digibyte/digibyte/).

## After

> For translation contributions and discussions, please join the [DigiByte Translations Telegram group](https://t.me/DigiByteTranslations).

Closes #371