### PR TITLE
wallet: fix redeemdigidollar failure on wallets with fragmented DGB UTXOs

### DIFF
--- a/REPO_MAP_DIGIDOLLAR.md
+++ b/REPO_MAP_DIGIDOLLAR.md
@@ -99,6 +99,8 @@ This is the granular file index for all DigiDollar and Oracle source code. Read 
 - Global `g_scriptMetadataMap` protected by `RecursiveMutex`, capped at 10,000 entries
 
 ### src/digidollar/txbuilder.h
+- `DigiDollar::MIN_DD_FEE_RATE` = 35,000,000 sat/kvB (0.35 DGB/kvB) → the DigiDollar fee rate; shared by mint/transfer/redeem RPCs and wallet coin selection
+- `DigiDollar::MIN_DD_TX_FEE` = 10,000,000 sat (0.1 DGB) → absolute fee floor for any DigiDollar transaction
 - `DigiDollar::TxBuilderResult` (struct) → result of tx building: success, CMutableTransaction, error string, totalFees, collateralRequired, ddChange
 - `DigiDollar::TxBuilderMintParams` (struct) → ddAmount, lockDays, lockTier (0-9), ownerKey, feeRate, utxos, optional dgbChangeDest
 - `DigiDollar::TxBuilderTransferParams` (struct) → recipients vector (address, amount), feeRate, ddUtxos, ddAmounts, feeUtxos, feeAmounts, spenderKey, optional dgbChangeDest
@@ -127,6 +129,7 @@ This is the granular file index for all DigiDollar and Oracle source code. Read 
   - `CreateRedemptionScript(path, owner)` → creates Schnorr-signed redemption script
 - `DigiDollar::EncodeDigiDollarAddress(dest, chainParams)` → converts CTxDestination to DD address string via CDigiDollarAddress
 - `DigiDollar::EstimateTransactionVSize(tx)` → estimates vsize with 110-byte witness per input + 35% safety margin
+- `DigiDollar::EstimateInputSpendCost(feeRate)` → approximate fee cost of one extra input (92 vB marginal measured against EstimateTransactionVSize at zero inputs → 3,220,000 sat at MIN_DD_FEE_RATE); a fee UTXO worth less has negative effective value. Approximation only: the estimator's double truncation makes the true marginal alternate 92/93 vB, absorbed by the redemption re-projection loop. Returns 0 for a non-positive rate, MAX_MONEY on overflow
 
 ### src/digidollar/txbuilder.cpp
 - Full implementation of all TxBuilder classes (~1,425 lines)
@@ -708,7 +711,8 @@ This is the granular file index for all DigiDollar and Oracle source code. Read 
     - `ProcessIncomingTransaction(tx, txid)` → processes any incoming DD tx and adds to history
   - **Coin Selection:**
     - `SelectDDCoins(target, selected_utxos, selected_total, amounts)` → selects DD UTXOs for target amount
-    - `SelectFeeCoins(fee_amount, selected_utxos, selected_total, amounts, exclude)` → selects DGB UTXOs for fees
+    - `SelectFeeCoins(fee_amount, selected_utxos, selected_total, amounts, exclude, minimize_inputs=false, fee_rate=MIN_DD_FEE_RATE)` → selects DGB UTXOs for fees. Prices candidates by EFFECTIVE value (value − `EstimateInputSpendCost(fee_rate)`): UTXOs that cost at least as much to spend as they are worth are skipped, and `fee_amount` must be met by the sum of effective values, not the raw sum (`selected_total` is still the raw total). Smallest-first by default (spends small UTXOs down, at the cost of a larger fee); `minimize_inputs=true` sorts largest-first for the fewest inputs
+    - `SelectRedemptionFeeCoins(params, error, projected_fee)` → `DDFeeSelectionResult` {OK, INSUFFICIENT_FUNDS, INVALID_TRANSACTION}. Fee-input selection for redemptions: excludes the collateral outpoint and the DD UTXOs being burned, then converges (≤6 rounds) by projecting the redemption tx, deriving the real fee from `EstimateTransactionVSize`, and re-selecting against it; enforces MAX_STANDARD_TX_WEIGHT and the MIN_DD_TX_FEE floor. Fills `params.feeUtxos`/`feeAmounts`; `projected_fee` is an upper bound
     - `CalculateTransactionFee(tx)` → estimates fee for transaction
   - **Utility:**
     - `IsLockedByDD(outpoint)` → checks if outpoint is locked by DD (protects from UnlockAllCoins)

--- a/src/digidollar/txbuilder.cpp
+++ b/src/digidollar/txbuilder.cpp
@@ -34,7 +34,6 @@ static const size_t ESTIMATED_TX_VSIZE = 500;      // Estimated transaction size
 static const int DEFAULT_SYSTEM_COLLATERAL = 150;   // Default system health (150%)
 static const double MAX_FEE_RATIO = 0.5;           // Maximum fee as ratio of total input
 static const size_t MAX_TX_INPUTS = 400;           // Maximum inputs per transaction to stay under MAX_STANDARD_TX_WEIGHT
-static const CAmount MIN_DD_TX_FEE = 10000000;     // 0.1 DGB minimum DD transaction fee
 
 CAmount ApplyCollateralSafetyMargin(CAmount requiredCollateral)
 {
@@ -1295,14 +1294,24 @@ TxBuilderResult RedeemTxBuilder::BuildRedemptionTransaction(const TxBuilderRedee
     LogPrintf("DigiDollar: Calculated fees: %d sats (fee inputs: %d sats)\n", result.totalFees, totalFeeIn);
 
     if (totalFeeIn <= 0) {
-        result.error = "Insufficient fee inputs for DD redemption fee";
+        result.error = strprintf("Insufficient fee inputs for DD redemption fee: no DGB fee input was supplied "
+                                 "for a transaction that owes %lld sats. Fund the wallet with spendable DGB and retry.",
+                                 static_cast<long long>(result.totalFees));
         LogPrintf("DigiDollar: BuildRedemptionTransaction FAILED - %s\n", result.error);
         return result;
     }
 
     CAmount feeChange = totalFeeIn - result.totalFees;
     if (feeChange < 0) {
-        result.error = "Insufficient fee inputs for DD redemption fee";
+        // Every fee input costs a fee of its own to spend, so a pile of small
+        // UTXOs can total more than the fee and still not pay it.
+        result.error = strprintf("Insufficient fee inputs for DD redemption fee: %u fee input(s) totalling %lld sats "
+                                 "against a %lld sat fee (each extra fee input costs about %lld sats to spend). "
+                                 "Consolidate small DGB UTXOs into fewer, larger ones and retry.",
+                                 static_cast<unsigned>(params.feeUtxos.size()),
+                                 static_cast<long long>(totalFeeIn),
+                                 static_cast<long long>(result.totalFees),
+                                 static_cast<long long>(EstimateInputSpendCost(params.feeRate)));
         LogPrintf("DigiDollar: BuildRedemptionTransaction FAILED - %s\n", result.error);
         return result;
     }
@@ -1488,6 +1497,29 @@ size_t EstimateTransactionVSize(const CMutableTransaction& tx) {
     // Add 35% safety margin to account for estimation errors
     // Taproot transactions with script-path spending can be larger than key-path estimates
     return vsize + (vsize * 35 / 100);
+}
+
+namespace {
+//! Marginal vsize of one extra input, measured against EstimateTransactionVSize()
+//! at zero inputs. The estimator truncates twice, so the true marginal alternates
+//! between 92 and 93 vB with the size of the rest of the transaction; this is the
+//! lower of the two and therefore an approximation, not a bound. See
+//! EstimateInputSpendCost() in the header.
+size_t EstimateInputVSize() {
+    CMutableTransaction probe;
+    const size_t without_input = EstimateTransactionVSize(probe);
+    probe.vin.emplace_back();
+    const size_t with_input = EstimateTransactionVSize(probe);
+    return with_input - without_input;
+}
+} // namespace
+
+CAmount EstimateInputSpendCost(CAmount feeRate) {
+    if (feeRate <= 0) return 0;
+    const CAmount vsize = static_cast<CAmount>(EstimateInputVSize());
+    // Fee rates reach this from RPC parameters, so guard the multiply.
+    if (feeRate > std::numeric_limits<CAmount>::max() / vsize) return MAX_MONEY;
+    return (vsize * feeRate) / 1000;
 }
 
 } // namespace DigiDollar

--- a/src/digidollar/txbuilder.h
+++ b/src/digidollar/txbuilder.h
@@ -21,6 +21,16 @@
 
 namespace DigiDollar {
 
+/**
+ * Minimum fee rate for DigiDollar transactions, in satoshis per kvB
+ * (0.35 DGB/kvB, i.e. 35,000 sat/vB). DigiByte expresses fee rates per
+ * kilo-vbyte, not per vbyte.
+ */
+static constexpr CAmount MIN_DD_FEE_RATE{35000000};
+
+/** Absolute fee floor for any DigiDollar transaction (0.1 DGB). */
+static constexpr CAmount MIN_DD_TX_FEE{10000000};
+
 // Apply the wallet mint collateral safety margin used by MintTxBuilder.
 // The input and output are DGB satoshis.
 CAmount ApplyCollateralSafetyMargin(CAmount requiredCollateral);
@@ -312,6 +322,28 @@ std::string EncodeDigiDollarAddress(const CTxDestination& dest, const CChainPara
  * @return Estimated virtual size in vBytes
  */
 size_t EstimateTransactionVSize(const CMutableTransaction& tx);
+
+/**
+ * Approximate fee that spending one additional input costs at the given fee rate.
+ *
+ * A fee UTXO worth less than this has negative effective value: adding it to a
+ * transaction reduces, rather than increases, the amount available to pay the
+ * fee. Coin selection for DigiDollar fee inputs prices inputs with this.
+ *
+ * The marginal input size is measured against EstimateTransactionVSize() at zero
+ * inputs and comes out at 92 vB (41 base bytes plus the flat 110-byte witness
+ * allowance, i.e. 68.5 vB, carrying the estimator's 35% margin). It is an
+ * approximation, not an exact per-input cost: EstimateTransactionVSize()
+ * truncates twice, so the true marginal alternates between 92 and 93 vB
+ * depending on the size of the rest of the transaction. Callers that must not
+ * come up short re-project the transaction and re-select (see
+ * DigiDollarWallet::SelectRedemptionFeeCoins), which absorbs the difference.
+ *
+ * @param feeRate Fee rate in satoshis per kvB
+ * @return Cost in satoshis of spending one extra input, 0 for a non-positive
+ *         fee rate, MAX_MONEY if the fee rate is large enough to overflow
+ */
+CAmount EstimateInputSpendCost(CAmount feeRate);
 
 } // namespace DigiDollar
 

--- a/src/rpc/digidollar.cpp
+++ b/src/rpc/digidollar.cpp
@@ -1308,9 +1308,8 @@ RPCHelpMan mintdigidollar()
             // MIN_DD_TX_FEE = 10,000,000 satoshis = 0.1 DGB
             // For a typical 300-byte tx, we need feeRate = 10,000,000 / 300 * 1000 = 33,333,333 sat/kB
             // We use 35,000,000 sat/kB to ensure minimum is always met
-            static const CAmount MIN_DD_FEE_RATE = 35000000; // 0.35 DGB/kB ensures min 0.1 DGB for typical tx
             CAmount feeRate = OptionalParamIsSet(request, 2) ?
-                std::max(request.params[2].getInt<int64_t>(), MIN_DD_FEE_RATE) : MIN_DD_FEE_RATE;
+                std::max<CAmount>(request.params[2].getInt<int64_t>(), DigiDollar::MIN_DD_FEE_RATE) : DigiDollar::MIN_DD_FEE_RATE;
 
             // Validate parameters
             if (ddAmount <= 0) {
@@ -2307,8 +2306,7 @@ RPCHelpMan redeemdigidollar()
             redeemParams.path = errRedemptionActive ? DigiDollar::RedemptionPath::ERR : DigiDollar::RedemptionPath::NORMAL;
             redeemParams.ownerKey = ownerKey;  // BUG #10 FIX: Use position owner key directly
             // DigiDollar transactions MUST pay at least 0.1 DGB fee to miners
-            static const CAmount MIN_DD_FEE_RATE = 35000000; // 0.35 DGB/kB ensures min 0.1 DGB for typical tx
-            redeemParams.feeRate = MIN_DD_FEE_RATE;
+            redeemParams.feeRate = DigiDollar::MIN_DD_FEE_RATE; // 0.35 DGB/kB ensures min 0.1 DGB for typical tx
 
             // Use the caller's requested DGB return address if supplied. If no
             // address is supplied, create a wallet destination so the returned
@@ -2374,33 +2372,26 @@ RPCHelpMan redeemdigidollar()
             LogPrintf("  - DD Minted: %d cents\n", foundPosition.dd_minted);
             LogPrintf("  - Unlock Height: %d\n", foundPosition.unlock_height);
 
-            // Select fee UTXOs from wallet
-            // CRITICAL: Build exclude list to prevent selecting collateral or DD UTXOs as fee inputs
-            std::vector<COutPoint> exclude_utxos;
-            exclude_utxos.push_back(redeemParams.collateralOutpoint);  // Don't select collateral
-            exclude_utxos.insert(exclude_utxos.end(), redeemParams.ddUtxos.begin(), redeemParams.ddUtxos.end());  // Don't select DD UTXOs
-
-            LogPrintf("DigiDollar: Building exclude list with %d UTXOs (1 collateral + %d DD)\n",
-                      exclude_utxos.size(), redeemParams.ddUtxos.size());
-
-            // Bug #9 fix: Calculate fee from feeRate and estimated tx size instead of hardcoding.
-            // Redemption tx: ~3 inputs (collateral + DD + fee), ~2-3 outputs → ~400 vbytes.
-            // Apply 50% safety margin for script-path spending variance.
-            CAmount estimatedFee = (400 * redeemParams.feeRate) / 1000; // vsize * feeRate / 1000
-            estimatedFee = estimatedFee + (estimatedFee / 2); // 50% safety margin
-            if (estimatedFee < 10000000) estimatedFee = 10000000; // Floor at 0.1 DGB
-            LogPrintf("DigiDollar: Estimated redemption fee: %lld sats (%.8f DGB)\n",
-                      static_cast<long long>(estimatedFee), estimatedFee / 100000000.0);
-            CAmount selectedFeeTotal = 0;
-            std::vector<CAmount> feeAmounts;
-
-            if (!dd_wallet->SelectFeeCoins(estimatedFee, redeemParams.feeUtxos, selectedFeeTotal, &feeAmounts, &exclude_utxos)) {
-                throw JSONRPCError(RPC_WALLET_INSUFFICIENT_FUNDS, "Insufficient DGB balance for transaction fees");
+            // Select fee UTXOs from the wallet. A fixed size guess cannot work
+            // here: the fee a redemption owes depends on how many fee inputs it
+            // ends up carrying, and each input costs a fee of its own to spend.
+            // SelectRedemptionFeeCoins() re-projects the transaction after every
+            // selection round, and excludes the collateral outpoint and the DD
+            // UTXOs being burned from the candidate set.
+            std::string feeSelectionError;
+            CAmount projectedFee = 0;
+            switch (dd_wallet->SelectRedemptionFeeCoins(redeemParams, feeSelectionError, &projectedFee)) {
+            case DDFeeSelectionResult::OK:
+                break;
+            case DDFeeSelectionResult::INSUFFICIENT_FUNDS:
+                throw JSONRPCError(RPC_WALLET_INSUFFICIENT_FUNDS, feeSelectionError);
+            case DDFeeSelectionResult::INVALID_TRANSACTION:
+                // Not a funding problem: the redemption cannot be built as asked.
+                throw JSONRPCError(RPC_WALLET_ERROR, feeSelectionError);
             }
 
-            redeemParams.feeAmounts = feeAmounts;
-            LogPrintf("DigiDollar: Selected %d sats in fees from %d UTXOs for redemption\n",
-                     selectedFeeTotal, redeemParams.feeUtxos.size());
+            LogPrintf("DigiDollar: Selected %zu fee UTXOs for redemption (projected fee at most %lld sats)\n",
+                      redeemParams.feeUtxos.size(), static_cast<long long>(projectedFee));
 
             DigiDollar::TxBuilderResult redeemResult = redeemBuilder.BuildRedemptionTransaction(redeemParams);
 

--- a/src/test/digidollar_wallet_tests.cpp
+++ b/src/test/digidollar_wallet_tests.cpp
@@ -10,7 +10,10 @@
 #include <wallet/transaction.h>
 #include <wallet/wallet.h>
 #include <digidollar/digidollar.h>
+#include <digidollar/txbuilder.h>
 #include <digidollar/validation.h>
+#include <addresstype.h>
+#include <outputtype.h>
 #include <primitives/transaction.h>
 #include <script/script.h>
 #include <key.h>
@@ -20,6 +23,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include <algorithm>
+#include <memory>
 
 using namespace DigiDollar;
 
@@ -99,6 +103,54 @@ struct DDWalletTestFixture : public TestingSetup {
         tx.incoming = incoming;
         tx.address = CreateDDAddress(incoming ? walletKey.GetPubKey() : recipientKey.GetPubKey());
         return tx;
+    }
+
+    //! Keeps every synthetic funding txid produced below distinct.
+    uint32_t m_next_funding_locktime{0};
+
+    /**
+     * Create an empty descriptor wallet that can be stocked with exact-value
+     * DGB UTXOs via AddConfirmedUTXO(). Its chain tip is set to height 200 so
+     * anything added at height 101 is deeply confirmed (SelectFeeCoins skips
+     * depth < 1 while Dandelion is on).
+     */
+    std::unique_ptr<wallet::CWallet> CreateFeeSelectionWallet(const std::string& name) {
+        auto cwallet = std::make_unique<wallet::CWallet>(
+            m_node.chain.get(), name, wallet::CreateMockableWalletDatabase());
+        BOOST_REQUIRE(cwallet->LoadWallet() == wallet::DBErrors::LOAD_OK);
+        LOCK(cwallet->cs_wallet);
+        cwallet->SetWalletFlag(wallet::WALLET_FLAG_DESCRIPTORS);
+        cwallet->SetupDescriptorScriptPubKeyMans();
+        cwallet->SetLastBlockProcessed(200, InsecureRand256());
+        return cwallet;
+    }
+
+    /** Add one confirmed, spendable DGB UTXO of `value` satoshis. */
+    COutPoint AddConfirmedUTXO(wallet::CWallet& cwallet, CAmount value) {
+        LOCK(cwallet.cs_wallet);
+        CMutableTransaction tx;
+        tx.nLockTime = m_next_funding_locktime++;
+        tx.vout.resize(1);
+        tx.vout[0].nValue = value;
+        tx.vout[0].scriptPubKey = GetScriptForDestination(
+            *Assert(cwallet.GetNewDestination(OutputType::BECH32, "")));
+        CTransactionRef txref = MakeTransactionRef(std::move(tx));
+        BOOST_REQUIRE(cwallet.AddToWallet(
+            txref, wallet::TxStateConfirmed{InsecureRand256(), /*height=*/101, /*index=*/0}) != nullptr);
+        return COutPoint(txref->GetHash(), 0);
+    }
+
+    /** Redemption parameters with no fee inputs chosen yet. */
+    DigiDollar::TxBuilderRedeemParams MakeRedeemParams(CAmount fee_rate = DigiDollar::MIN_DD_FEE_RATE) {
+        DigiDollar::TxBuilderRedeemParams params;
+        params.collateralOutpoint = COutPoint(InsecureRand256(), 0);
+        params.collateralAmount = 20000000000;  // 200 DGB locked
+        params.ddToRedeem = TEST_DD_AMOUNT;     // $100.00
+        params.ddMinted = TEST_DD_AMOUNT;
+        params.ddUtxos = {COutPoint(InsecureRand256(), 1)};
+        params.ddAmounts = {TEST_DD_AMOUNT};
+        params.feeRate = fee_rate;
+        return params;
     }
 };
 
@@ -2032,6 +2084,338 @@ BOOST_FIXTURE_TEST_CASE(test_select_fee_coins_clears_on_failure, DDWalletTestFix
     BOOST_CHECK_EQUAL(result, false);
     BOOST_CHECK_EQUAL(total, 0);  // Should be cleared
     BOOST_CHECK_EQUAL(selected.size(), 0);  // Should be cleared
+}
+
+/**
+ * REGRESSION: redeemdigidollar fails with
+ *   "Insufficient fee inputs for DD redemption fee"
+ * on a wallet whose DGB is fragmented into small UTXOs, even though the wallet
+ * holds plenty of spendable DGB.
+ *
+ * DigiDollarWallet::SelectFeeCoins() sorts the wallet's spendable DGB UTXOs
+ * SMALLEST-FIRST (src/wallet/digidollarwallet.cpp, std::sort in SelectFeeCoins)
+ * and breaks out of the loop as soon as the RAW sum of the picked UTXOs reaches
+ * the requested fee. It never accounts for what it costs to *spend* each input
+ * it just added. On a fragmented wallet it therefore hands back a pile of tiny
+ * UTXOs whose real (net) contribution to the fee is far below the target, and
+ * DigiDollar::BuildRedemptionTransaction() -- which recomputes the fee from the
+ * transaction it actually built -- then hard-fails with
+ * "Insufficient fee inputs for DD redemption fee". There is no re-selection.
+ *
+ * ---------------------------------------------------------------------------
+ * Per-fee-input cost arithmetic (every number comes from the shipped code)
+ * ---------------------------------------------------------------------------
+ * DigiDollar::EstimateTransactionVSize() (src/digidollar/txbuilder.cpp):
+ *   - each extra input adds to the serialized BASE size:
+ *         32 (prevout hash) + 4 (prevout n) + 1 (empty scriptSig len)
+ *       +  4 (nSequence)                                       =  41 bytes
+ *   - each extra input adds a flat  110 bytes of WITNESS
+ *       (conservative P2TR script-path estimate, hardcoded)
+ *   - vsize = base + witness/4  =>  41 + 110/4                 =  68.5 vB
+ *   - the function then adds a 35% safety margin:
+ *         68.5 * 1.35                                          = ~92   vB
+ *
+ * Redemptions pay MIN_DD_FEE_RATE = 35,000,000 sat/kvB (src/rpc/digidollar.cpp),
+ * i.e. 35,000 sat/vB, so every extra fee input costs
+ *         ~92 vB * 35,000 sat/vB = ~3,220,000 sat = ~0.0322 DGB
+ *
+ * => a fee UTXO's EFFECTIVE contribution is (value - ~0.0322 DGB).
+ *    Any fee UTXO smaller than ~0.0322 DGB has NEGATIVE effective value.
+ *
+ * ---------------------------------------------------------------------------
+ * Scenario modelled here (the reported reproduction)
+ * ---------------------------------------------------------------------------
+ * Wallet holds:
+ *   - 8 fragmented UTXOs of 0.0525 DGB (5,250,000 sat) each
+ *       effective each:  5,250,000 - 3,220,000 =   2,030,000 sat
+ *       all 8 together: 42,000,000 - 25,760,000 =  16,240,000 sat  (< target)
+ *   - 1 large UTXO of 5 DGB (500,000,000 sat)
+ *       effective:     500,000,000 - 3,220,000 = 496,780,000 sat  (>> target)
+ *
+ * Target fee = exactly what redeemdigidollar asks SelectFeeCoins for
+ * (src/rpc/digidollar.cpp):
+ *       (400 vB * 35,000,000) / 1000 = 14,000,000
+ *       + 50% safety margin          = 21,000,000 sat  (floor 10,000,000)
+ *
+ * CORRECT behaviour: the returned selection must still cover the target fee
+ * AFTER paying to spend the inputs it selected. Here that is only achievable
+ * by using the 5 DGB UTXO -- the eight small ones cannot cover it even all
+ * together.
+ *
+ * CURRENT (buggy) behaviour: smallest-first + raw-sum break picks exactly four
+ * 0.0525 DGB UTXOs (4 * 5,250,000 == 21,000,000, target "reached"), leaves the
+ * 5 DGB UTXO untouched, and reports success with an effective value of only
+ *       21,000,000 - 4 * 3,220,000 = 8,120,000 sat
+ * i.e. 12,880,000 sat short of the fee it is supposed to pay.
+ */
+BOOST_FIXTURE_TEST_CASE(test_select_fee_coins_fragmented_uneconomic_utxos, DDWalletTestFixture)
+{
+    // Marginal cost of adding one more fee input, in satoshis (see block above),
+    // taken from the shipped helper so this test prices inputs the way the
+    // selector does. Note the helper is an approximation: it measures the
+    // marginal input at zero inputs (92 vB), while the estimator's double
+    // truncation makes the true marginal alternate between 92 and 93 vB.
+    const CAmount PER_INPUT_SPEND_COST =
+        DigiDollar::EstimateInputSpendCost(DigiDollar::MIN_DD_FEE_RATE);
+    // Tripwire, not an invariant: the arithmetic in the comment block above is
+    // derived from this exact value, so re-derive it if the estimator changes.
+    BOOST_REQUIRE_EQUAL(PER_INPUT_SPEND_COST, 3220000);        // 92 vB * 35,000 sat/vB
+    // Fee a redemption asks SelectFeeCoins() to cover.
+    static constexpr CAmount TARGET_FEE           = 21000000;  // 0.21 DGB
+    // Fragmented change-sized UTXOs.
+    static constexpr CAmount SMALL_UTXO           = 5250000;   // 0.0525 DGB
+    static constexpr int     NUM_SMALL_UTXOS      = 8;
+    // One comfortably economic UTXO that covers the whole fee on its own.
+    static constexpr CAmount LARGE_UTXO           = 500000000; // 5 DGB
+
+    // --- A real descriptor wallet we can stock with exact-value UTXOs --------
+    auto cwallet = CreateFeeSelectionWallet("dd-fee-fragmentation");
+    for (int i = 0; i < NUM_SMALL_UTXOS; ++i) {
+        AddConfirmedUTXO(*cwallet, SMALL_UTXO);
+    }
+    const COutPoint large_outpoint = AddConfirmedUTXO(*cwallet, LARGE_UTXO);
+
+    DigiDollarWallet wallet;
+    wallet.SetWallet(cwallet.get());
+
+    // --- Act ----------------------------------------------------------------
+    std::vector<COutPoint> selected;
+    std::vector<CAmount> selected_amounts;
+    CAmount selected_total = 0;
+
+    const bool ok = wallet.SelectFeeCoins(TARGET_FEE, selected, selected_total, &selected_amounts);
+
+    // The wallet holds 5.42 DGB of confirmed spendable DGB against a 0.21 DGB
+    // fee, so selection must succeed at all.
+    BOOST_REQUIRE_MESSAGE(ok, "SelectFeeCoins failed outright despite 5.42 DGB spendable");
+    BOOST_REQUIRE(!selected.empty());
+    BOOST_REQUIRE_EQUAL(selected.size(), selected_amounts.size());
+
+    // --- Assert the property that SHOULD hold -------------------------------
+    // The selection has to cover the fee once the cost of spending each input
+    // it chose is subtracted. Anything less and BuildRedemptionTransaction()
+    // aborts with "Insufficient fee inputs for DD redemption fee".
+    const CAmount input_spend_cost = static_cast<CAmount>(selected.size()) * PER_INPUT_SPEND_COST;
+    const CAmount effective_value = selected_total - input_spend_cost;
+
+    BOOST_CHECK_MESSAGE(effective_value >= TARGET_FEE,
+        "SelectFeeCoins returned an uneconomic fragmented selection: "
+        << selected.size() << " input(s) totalling " << selected_total
+        << " sat, minus " << input_spend_cost << " sat to spend them ("
+        << PER_INPUT_SPEND_COST << " sat/input), leaves only " << effective_value
+        << " sat towards a " << TARGET_FEE << " sat fee (short by "
+        << (TARGET_FEE - effective_value) << " sat). "
+        << "A single " << LARGE_UTXO << " sat UTXO was available and would have covered it.");
+
+    // The eight 0.0525 DGB UTXOs cannot cover this fee even all together
+    // (42,000,000 - 8 * 3,220,000 = 16,240,000 < 21,000,000), so no correct
+    // selection exists that leaves the large UTXO out. This call uses the
+    // default smallest-first order, so it reaches the large UTXO only after
+    // taking all eight small ones; the redemption path opts into
+    // minimize_inputs and picks the large UTXO on its own (see
+    // test_select_redemption_fee_coins_converges_on_fragmented_wallet).
+    const bool used_large_utxo =
+        std::find(selected.begin(), selected.end(), large_outpoint) != selected.end();
+    BOOST_CHECK_MESSAGE(used_large_utxo,
+        "SelectFeeCoins left the only economically viable fee UTXO ("
+        << LARGE_UTXO << " sat) unused and picked " << selected.size()
+        << " fragmented UTXO(s) instead");
+}
+
+/** Sum of the fee amounts a redemption selection returned. */
+static CAmount TotalFeeInputs(const DigiDollar::TxBuilderRedeemParams& params)
+{
+    CAmount total = 0;
+    for (const CAmount amount : params.feeAmounts) total += amount;
+    return total;
+}
+
+/**
+ * Companion to the regression above, on the redemption path proper:
+ * DigiDollarWallet::SelectRedemptionFeeCoins() must return a fee selection that
+ * covers the fee of the transaction that will actually be built from it (the
+ * check BuildRedemptionTransaction() applies), using as few inputs as possible.
+ */
+BOOST_FIXTURE_TEST_CASE(test_select_redemption_fee_coins_converges_on_fragmented_wallet, DDWalletTestFixture)
+{
+    static constexpr CAmount SMALL_UTXO      = 5250000;    // 0.0525 DGB, uneconomic on its own
+    static constexpr int     NUM_SMALL_UTXOS = 8;
+    static constexpr CAmount LARGE_UTXO      = 500000000;  // 5 DGB
+
+    auto cwallet = CreateFeeSelectionWallet("dd-redeem-fee-convergence");
+    for (int i = 0; i < NUM_SMALL_UTXOS; ++i) AddConfirmedUTXO(*cwallet, SMALL_UTXO);
+    const COutPoint large_outpoint = AddConfirmedUTXO(*cwallet, LARGE_UTXO);
+
+    DigiDollarWallet wallet;
+    wallet.SetWallet(cwallet.get());
+
+    DigiDollar::TxBuilderRedeemParams params = MakeRedeemParams();
+    std::string error;
+    CAmount projected_fee = 0;
+    BOOST_REQUIRE_MESSAGE(wallet.SelectRedemptionFeeCoins(params, error, &projected_fee) == DDFeeSelectionResult::OK, error);
+    BOOST_REQUIRE_EQUAL(params.feeUtxos.size(), params.feeAmounts.size());
+    BOOST_REQUIRE(!params.feeUtxos.empty());
+
+    // The selection must pay the projected fee outright - that is exactly the
+    // totalFeeIn >= totalFees test BuildRedemptionTransaction() applies.
+    const CAmount selected_total = TotalFeeInputs(params);
+    BOOST_CHECK_MESSAGE(selected_total >= projected_fee,
+        "Redemption fee selection of " << selected_total << " sat across "
+        << params.feeUtxos.size() << " input(s) does not cover the projected "
+        << projected_fee << " sat fee");
+
+    // And it must do so with the single economic UTXO rather than dragging in
+    // the fragmented ones, each of which would add more fee than it contributes.
+    BOOST_CHECK_EQUAL(params.feeUtxos.size(), 1U);
+    BOOST_CHECK(params.feeUtxos.front() == large_outpoint);
+}
+
+/**
+ * A redemption must never pay its fee out of the collateral it is releasing or
+ * out of the DD tokens it is burning: those inputs are already spent by the
+ * transaction, so selecting them again would build a double-spend. Guards the
+ * exclude list SelectRedemptionFeeCoins() builds from the redemption params.
+ */
+BOOST_FIXTURE_TEST_CASE(test_select_redemption_fee_coins_never_spends_collateral_or_dd, DDWalletTestFixture)
+{
+    // All three are wallet-owned and individually cover the fee, so nothing but
+    // the exclude list can keep the first two out of the selection.
+    //
+    // The values are deliberately DESCENDING, with the only selectable UTXO the
+    // smallest. SelectRedemptionFeeCoins() sorts largest-first and stops as soon
+    // as the target is covered, so this forces both excluded outpoints to be
+    // examined - and skipped - before the free one is reached. Equal values would
+    // leave candidate order up to mapWallet's unordered_map iteration (salted by
+    // the real RNG, so it varies per process) and the exclusion branch would go
+    // unexercised on the runs where the free UTXO happened to come first.
+    static constexpr CAmount COLLATERAL_UTXO = 700000000;  // 7 DGB
+    static constexpr CAmount DD_TOKEN_UTXO   = 600000000;  // 6 DGB
+    static constexpr CAmount FREE_UTXO       = 500000000;  // 5 DGB, still ample
+
+    auto cwallet = CreateFeeSelectionWallet("dd-redeem-fee-exclusions");
+    const COutPoint collateral_outpoint = AddConfirmedUTXO(*cwallet, COLLATERAL_UTXO);
+    const COutPoint dd_outpoint         = AddConfirmedUTXO(*cwallet, DD_TOKEN_UTXO);
+    const COutPoint free_outpoint       = AddConfirmedUTXO(*cwallet, FREE_UTXO);
+
+    DigiDollarWallet wallet;
+    wallet.SetWallet(cwallet.get());
+
+    DigiDollar::TxBuilderRedeemParams params = MakeRedeemParams();
+    params.collateralOutpoint = collateral_outpoint;
+    params.ddUtxos = {dd_outpoint};
+    params.ddAmounts = {TEST_DD_AMOUNT};
+
+    std::string error;
+    CAmount projected_fee = 0;
+    BOOST_REQUIRE_MESSAGE(wallet.SelectRedemptionFeeCoins(params, error, &projected_fee) == DDFeeSelectionResult::OK, error);
+    BOOST_REQUIRE(!params.feeUtxos.empty());
+
+    const auto contains = [&params](const COutPoint& outpoint) {
+        return std::find(params.feeUtxos.begin(), params.feeUtxos.end(), outpoint) != params.feeUtxos.end();
+    };
+    BOOST_CHECK_MESSAGE(!contains(collateral_outpoint),
+        "Redemption fee selection picked the collateral outpoint it is releasing");
+    BOOST_CHECK_MESSAGE(!contains(dd_outpoint),
+        "Redemption fee selection picked a DD token outpoint it is burning");
+    BOOST_CHECK(contains(free_outpoint));
+    BOOST_CHECK_EQUAL(params.feeUtxos.size(), 1U);
+    BOOST_CHECK_GE(TotalFeeInputs(params), projected_fee);
+}
+
+/**
+ * A wallet holding nothing but sub-cost dust cannot fund a redemption at all.
+ * The failure has to say so in terms the user can act on, and must leave no
+ * fee inputs behind on the params.
+ */
+BOOST_FIXTURE_TEST_CASE(test_select_redemption_fee_coins_dust_only_wallet_fails_actionably, DDWalletTestFixture)
+{
+    // Below DigiDollar::EstimateInputSpendCost(MIN_DD_FEE_RATE) == 3,220,000 sat,
+    // so each of these costs more to spend than it is worth.
+    static constexpr CAmount DUST_UTXO  = 1000000;  // 0.01 DGB
+    static constexpr int     NUM_DUST   = 50;       // 0.5 DGB in total
+
+    auto cwallet = CreateFeeSelectionWallet("dd-redeem-fee-dust-only");
+    for (int i = 0; i < NUM_DUST; ++i) AddConfirmedUTXO(*cwallet, DUST_UTXO);
+
+    DigiDollarWallet wallet;
+    wallet.SetWallet(cwallet.get());
+
+    DigiDollar::TxBuilderRedeemParams params = MakeRedeemParams();
+    std::string error;
+    BOOST_CHECK(wallet.SelectRedemptionFeeCoins(params, error) == DDFeeSelectionResult::INSUFFICIENT_FUNDS);
+    BOOST_CHECK(params.feeUtxos.empty());
+    BOOST_CHECK(params.feeAmounts.empty());
+    BOOST_CHECK_MESSAGE(error.find("consolidate") != std::string::npos,
+        "Fee selection failure does not tell the user to consolidate: " << error);
+}
+
+/** A wallet with no spendable DGB at all fails the same way, without crashing. */
+BOOST_FIXTURE_TEST_CASE(test_select_redemption_fee_coins_empty_wallet_fails, DDWalletTestFixture)
+{
+    auto cwallet = CreateFeeSelectionWallet("dd-redeem-fee-empty");
+
+    DigiDollarWallet wallet;
+    wallet.SetWallet(cwallet.get());
+
+    DigiDollar::TxBuilderRedeemParams params = MakeRedeemParams();
+    std::string error;
+    BOOST_CHECK(wallet.SelectRedemptionFeeCoins(params, error) == DDFeeSelectionResult::INSUFFICIENT_FUNDS);
+    BOOST_CHECK(params.feeUtxos.empty());
+    BOOST_CHECK(params.feeAmounts.empty());
+    BOOST_CHECK(!error.empty());
+}
+
+/**
+ * The per-input cost has to follow the fee rate the redemption actually pays.
+ * At the lowest fee rate ValidateFeeRate accepts (100,000 sat/kvB) an input
+ * costs ~9,200 sat, not the ~3,220,000 sat it costs at the DigiDollar minimum,
+ * so 0.05 DGB UTXOs are perfectly economic. Pricing them at a hardcoded
+ * DigiDollar rate would reject this fundable redemption.
+ *
+ * This is also the case where the MIN_DD_TX_FEE floor genuinely binds: a
+ * ~580 vB redemption at 100,000 sat/kvB owes ~58,000 sat by size, well under
+ * the 0.1 DGB DigiDollar minimum.
+ */
+BOOST_FIXTURE_TEST_CASE(test_select_redemption_fee_coins_prices_inputs_at_caller_fee_rate, DDWalletTestFixture)
+{
+    static constexpr CAmount LOW_FEE_RATE = 100000;   // 0.001 DGB/kvB
+    static constexpr CAmount UTXO_VALUE   = 5000000;  // 0.05 DGB
+    static constexpr int     NUM_UTXOS    = 3;        // 0.15 DGB total
+
+    auto cwallet = CreateFeeSelectionWallet("dd-redeem-fee-low-rate");
+    for (int i = 0; i < NUM_UTXOS; ++i) AddConfirmedUTXO(*cwallet, UTXO_VALUE);
+
+    DigiDollarWallet wallet;
+    wallet.SetWallet(cwallet.get());
+
+    BOOST_CHECK_EQUAL(DigiDollar::EstimateInputSpendCost(LOW_FEE_RATE), 9200);
+
+    DigiDollar::TxBuilderRedeemParams params = MakeRedeemParams(LOW_FEE_RATE);
+    std::string error;
+    CAmount projected_fee = 0;
+    BOOST_REQUIRE_MESSAGE(wallet.SelectRedemptionFeeCoins(params, error, &projected_fee) == DDFeeSelectionResult::OK, error);
+
+    // Size alone would owe far less than the floor, so the floor is what the
+    // selection had to cover.
+    BOOST_CHECK_EQUAL(projected_fee, DigiDollar::MIN_DD_TX_FEE);
+    BOOST_CHECK_GE(TotalFeeInputs(params), projected_fee);
+    BOOST_CHECK(!params.feeUtxos.empty());
+}
+
+/** A non-positive fee rate is a malformed redemption, not a funding shortfall. */
+BOOST_FIXTURE_TEST_CASE(test_select_redemption_fee_coins_rejects_invalid_fee_rate, DDWalletTestFixture)
+{
+    auto cwallet = CreateFeeSelectionWallet("dd-redeem-fee-bad-rate");
+    AddConfirmedUTXO(*cwallet, 500000000);
+
+    DigiDollarWallet wallet;
+    wallet.SetWallet(cwallet.get());
+
+    DigiDollar::TxBuilderRedeemParams params = MakeRedeemParams(/*fee_rate=*/0);
+    std::string error;
+    BOOST_CHECK(wallet.SelectRedemptionFeeCoins(params, error) == DDFeeSelectionResult::INVALID_TRANSACTION);
+    BOOST_CHECK(params.feeUtxos.empty());
+    BOOST_CHECK(!error.empty());
 }
 
 // =============================================================================

--- a/src/wallet/digidollarwallet.cpp
+++ b/src/wallet/digidollarwallet.cpp
@@ -38,8 +38,6 @@
 #include <set>
 
 namespace {
-static constexpr CAmount MIN_DD_TRANSFER_FEE_RATE{35000000}; // 0.35 DGB/kB
-static constexpr CAmount MIN_DD_TRANSFER_FEE{10000000};       // 0.1 DGB
 static constexpr CAmount TRANSFER_BUILDER_PRICE_UNUSED{1};    // Transfers are price-independent.
 
 CScript BuildDDTransferMetadataScript(const std::vector<CAmount>& amounts)
@@ -102,7 +100,68 @@ bool PreflightDDTransferCapacity(const DigiDollar::TxBuilderTransferParams& para
                           weight, static_cast<unsigned>(vsize), MAX_STANDARD_TX_WEIGHT);
         return false;
     }
-    const CAmount fee = std::max<CAmount>((static_cast<CAmount>(vsize) * MIN_DD_TRANSFER_FEE_RATE) / 1000, MIN_DD_TRANSFER_FEE);
+    const CAmount fee = std::max<CAmount>((static_cast<CAmount>(vsize) * DigiDollar::MIN_DD_FEE_RATE) / 1000, DigiDollar::MIN_DD_TX_FEE);
+    if (projected_vsize) *projected_vsize = vsize;
+    if (projected_fee) *projected_fee = fee;
+    return true;
+}
+
+/** Worst-case (largest) output script the redemption builder can emit. */
+CScript WorstCaseDDOutputScript()
+{
+    CScript script;
+    script << OP_1 << std::vector<unsigned char>(32, 0);
+    return script;
+}
+
+/**
+ * Project the redemption transaction RedeemTxBuilder::BuildRedemptionTransaction()
+ * will build for `params` (including the fee inputs currently held in
+ * params.feeUtxos) and derive the fee it will owe. Redemption counterpart of
+ * PreflightDDTransferCapacity: the fee follows from the built transaction, so it
+ * cannot be pinned down by a fixed size guess.
+ */
+bool PreflightDDRedemptionCapacity(const DigiDollar::TxBuilderRedeemParams& params,
+                                   std::string& error,
+                                   size_t* projected_vsize = nullptr,
+                                   CAmount* projected_fee = nullptr)
+{
+    if (params.feeRate <= 0) {
+        error = strprintf("Invalid DigiDollar redemption fee rate: %lld sat/kvB. The fee rate must be positive.",
+                          static_cast<long long>(params.feeRate));
+        return false;
+    }
+
+    CMutableTransaction projected;
+    projected.SetDigiDollarType(::DD_TX_REDEEM);
+    projected.vin.push_back(CTxIn(params.collateralOutpoint));
+    for (const auto& utxo : params.ddUtxos) projected.vin.push_back(CTxIn(utxo));
+    for (const auto& utxo : params.feeUtxos) projected.vin.push_back(CTxIn(utxo));
+
+    // Returned collateral.
+    projected.vout.push_back(CTxOut(params.collateralAmount,
+                                    params.collateralDest.has_value()
+                                        ? GetScriptForDestination(*params.collateralDest)
+                                        : WorstCaseDDOutputScript()));
+    // Worst-case DD change output plus the OP_RETURN that carries its amount,
+    // and the DGB fee change output. Including them unconditionally keeps the
+    // projection deterministic and never under-states the built transaction.
+    projected.vout.push_back(CTxOut(0, WorstCaseDDOutputScript()));
+    CScript metadata;
+    metadata << OP_RETURN << std::vector<unsigned char>{'D', 'D'} << CScriptNum(3) << CScriptNum(params.ddToRedeem);
+    projected.vout.push_back(CTxOut(0, metadata));
+    projected.vout.push_back(CTxOut(1, params.dgbChangeDest.has_value()
+                                           ? GetScriptForDestination(*params.dgbChangeDest)
+                                           : WorstCaseDDOutputScript()));
+
+    const size_t vsize = DigiDollar::EstimateTransactionVSize(projected);
+    const int64_t weight = static_cast<int64_t>(vsize) * WITNESS_SCALE_FACTOR;
+    if (weight > MAX_STANDARD_TX_WEIGHT) {
+        error = strprintf("Projected DigiDollar redemption is too large: %d weight units (%u vB) across %u inputs, standard limit is %d WU. Consolidate DGB or DD UTXOs first.",
+                          weight, static_cast<unsigned>(vsize), static_cast<unsigned>(projected.vin.size()), MAX_STANDARD_TX_WEIGHT);
+        return false;
+    }
+    const CAmount fee = std::max<CAmount>((static_cast<CAmount>(vsize) * params.feeRate) / 1000, DigiDollar::MIN_DD_TX_FEE);
     if (projected_vsize) *projected_vsize = vsize;
     if (projected_fee) *projected_fee = fee;
     return true;
@@ -1449,7 +1508,7 @@ bool DigiDollarWallet::TransferDigiDollarMany(const std::vector<std::pair<CDigiD
         DigiDollar::TxBuilderTransferParams params;
         params.recipients = plan.recipients;
         // DigiDollar transactions MUST pay at least 0.1 DGB fee to miners
-        params.feeRate = 35000000; // 0.35 DGB/kB = 0.105 DGB for 300 byte tx
+        params.feeRate = DigiDollar::MIN_DD_FEE_RATE; // 0.35 DGB/kB = 0.105 DGB for 300 byte tx
         params.ddUtxos = plan.dd_utxos;
         params.ddAmounts = plan.dd_amounts;
         LogPrintf("DigiDollar: Transfer - Selected %zu DD UTXOs totaling %lld cents\n",
@@ -3569,8 +3628,8 @@ std::vector<DDTransaction> DigiDollarWallet::GetRedemptionHistory() const {
 CAmount DigiDollarWallet::EstimateRedemptionFee(const COutPoint& position, DigiDollar::RedemptionPath path) const {
     auto locks = LockDDWallet();
     // Bug #9/#17 fix: Use actual DD fee rate for estimation
-    static const CAmount MIN_DD_TX_FEE = 10000000;       // 0.1 DGB minimum
-    static const CAmount FEE_RATE_PER_KB = 35000000;     // 0.35 DGB/kB (matches MIN_DD_FEE_RATE)
+    static const CAmount MIN_DD_TX_FEE = DigiDollar::MIN_DD_TX_FEE;
+    static const CAmount FEE_RATE_PER_KB = DigiDollar::MIN_DD_FEE_RATE;
 
     // Estimate transaction vsize based on redemption path
     // Redemption tx: 3 inputs (collateral + DD + fee), 2-3 outputs
@@ -5143,7 +5202,7 @@ bool DigiDollarWallet::TransferDigiDollar(const CDigiDollarAddress& to, CAmount 
         params.feeUtxos = fee_utxos;
         params.feeAmounts = fee_amounts;  // Pass actual fee UTXO amounts
         // DigiDollar transactions MUST pay at least 0.1 DGB fee to miners
-        params.feeRate = 35000000; // 0.35 DGB/kB = 0.105 DGB for 300 byte tx
+        params.feeRate = DigiDollar::MIN_DD_FEE_RATE; // 0.35 DGB/kB = 0.105 DGB for 300 byte tx
 
         // Get the spending key from wallet
         // For DD transfers, we need the key that owns the first DD UTXO
@@ -5558,7 +5617,7 @@ bool DigiDollarWallet::RedeemDigiDollar(const uint256& dd_timelock_id, const CAm
         }
 
         // DigiDollar transactions MUST pay at least 0.1 DGB fee to miners
-        params.feeRate = 35000000; // 0.35 DGB/kB = 0.105 DGB for 300 byte tx
+        params.feeRate = DigiDollar::MIN_DD_FEE_RATE; // 0.35 DGB/kB = 0.105 DGB for 300 byte tx
 
         // Select DD UTXOs to burn (any DD can be used - DD is fungible)
         // The key is to burn the EXACT amount that was minted for this vault
@@ -5574,31 +5633,18 @@ bool DigiDollarWallet::RedeemDigiDollar(const uint256& dd_timelock_id, const CAm
             LogPrintf("DigiDollar: ddAmounts[%zu] = %lld cents\n", i, static_cast<long long>(params.ddAmounts[i]));
         }
 
-        // Select DGB UTXOs for fees
-        // CRITICAL FIX: Properly estimate redemption transaction fees
-        // Redemption tx structure: 3 inputs (collateral + DD + fee), 2 outputs (return + change)
-        // Approximate vsize: ~400 bytes with script-path spending
-        // Fee calculation: vsize * feeRate / 1000 (feeRate is in sat/kB)
-        CAmount estimatedFee = (400 * params.feeRate) / 1000; // Proper fee estimate
-        // Add safety margin
-        estimatedFee = estimatedFee + (estimatedFee * 50 / 100); // 50% margin for worst case
-        LogPrintf("DigiDollar: Estimated redemption fee: %lld sats (%.8f DGB)\n", static_cast<long long>(estimatedFee), estimatedFee / 100000000.0);
-
-        // Build exclude list: collateral outpoint + all DD UTXOs that will be burned
-        std::vector<COutPoint> exclude_utxos;
-        exclude_utxos.push_back(params.collateralOutpoint);  // Don't select collateral as fee input
-        exclude_utxos.insert(exclude_utxos.end(), params.ddUtxos.begin(), params.ddUtxos.end());  // Don't select DD UTXOs as fee inputs
-
-        LogPrintf("DigiDollar: Built exclude list with %zu UTXOs (1 collateral + %zu DD)\n",
-                  exclude_utxos.size(), params.ddUtxos.size());
-
-        CAmount selectedFeeTotal = 0;
-        std::vector<CAmount> fee_amounts;
-        if (!SelectFeeCoins(estimatedFee, params.feeUtxos, selectedFeeTotal, &fee_amounts, &exclude_utxos)) {
-            LogPrintf("DigiDollar: Insufficient DGB balance for fees\n");
+        // Select DGB UTXOs for fees. The fee depends on how many inputs the
+        // redemption ends up carrying, so converge on it from the projected
+        // transaction instead of guessing a fixed size. This also excludes the
+        // collateral outpoint and the DD UTXOs being burned from selection.
+        std::string fee_error;
+        CAmount projectedFee = 0;
+        if (SelectRedemptionFeeCoins(params, fee_error, &projectedFee) != DDFeeSelectionResult::OK) {
+            LogPrintf("DigiDollar: %s\n", fee_error);
             return false;
         }
-        params.feeAmounts = fee_amounts;  // TxBuilder needs per-UTXO amounts for fee inputs
+        LogPrintf("DigiDollar: Selected %zu DGB fee input(s); projected redemption fee at most %lld sats\n",
+                  params.feeUtxos.size(), static_cast<long long>(projectedFee));
 
         LogPrintf("DigiDollar: CALLING BuildRedemptionTransaction now...\n");
         auto result = builder.BuildRedemptionTransaction(params);
@@ -6166,13 +6212,13 @@ bool DigiDollarWallet::PlanDigiDollarTransfer(const std::vector<std::pair<CDigiD
     params.recipients = plan.recipients;
     params.ddUtxos = plan.dd_utxos;
     params.ddAmounts = plan.dd_amounts;
-    params.feeRate = MIN_DD_TRANSFER_FEE_RATE;
+    params.feeRate = DigiDollar::MIN_DD_FEE_RATE;
     if (!PreflightDDTransferCapacity(params, plan.selected_dd_total, plan.total_amount, error, &plan.projected_vsize, &plan.estimated_fee)) return false;
 
     return true;
 }
 
-bool DigiDollarWallet::SelectFeeCoins(const CAmount& fee_amount, std::vector<COutPoint>& selected_utxos, CAmount& selected_total, std::vector<CAmount>* selected_amounts, const std::vector<COutPoint>* exclude_utxos) const {
+bool DigiDollarWallet::SelectFeeCoins(const CAmount& fee_amount, std::vector<COutPoint>& selected_utxos, CAmount& selected_total, std::vector<CAmount>* selected_amounts, const std::vector<COutPoint>* exclude_utxos, bool minimize_inputs, CAmount fee_rate) const {
     auto locks = LockDDWallet();
     // Reset output parameters
     selected_total = 0;
@@ -6182,6 +6228,13 @@ bool DigiDollarWallet::SelectFeeCoins(const CAmount& fee_amount, std::vector<COu
     // Validate fee amount
     if (fee_amount <= 0) {
         LogPrintf("DigiDollar: SelectFeeCoins - Invalid fee amount %lld\n", static_cast<long long>(fee_amount));
+        return false;
+    }
+
+    // The fee rate is what makes an input's cost - and therefore its effective
+    // value - meaningful, so it has to be a real rate.
+    if (fee_rate <= 0) {
+        LogPrintf("DigiDollar: SelectFeeCoins - Invalid fee rate %lld sat/kvB\n", static_cast<long long>(fee_rate));
         return false;
     }
 
@@ -6222,15 +6275,28 @@ bool DigiDollarWallet::SelectFeeCoins(const CAmount& fee_amount, std::vector<COu
 
     LogPrintf("DigiDollar: SelectFeeCoins - Found %zu available DGB UTXOs before filtering\n", available_coins.size());
 
-    // Sort by amount (smallest first for efficiency)
+    // Adding a fee input is not free: it enlarges the transaction the fee is
+    // computed from. Price every candidate by its effective value (value minus
+    // the cost of spending it) so the selection still covers the fee once the
+    // inputs it chose are paid for.
+    const CAmount input_spend_cost = DigiDollar::EstimateInputSpendCost(fee_rate);
+
+    // Sort by amount. Smallest first by default: that is the order DD transfers
+    // have always used, and it spends small UTXOs down rather than leaving them
+    // behind. It is not the cheapest order - every extra input it takes adds
+    // input_spend_cost to the fee actually paid - so callers that care about the
+    // fee, or that must converge on an exact one, pass minimize_inputs.
     std::sort(available_coins.begin(), available_coins.end(),
-              [](const wallet::COutput& a, const wallet::COutput& b) {
-                  return a.txout.nValue < b.txout.nValue;
+              [minimize_inputs](const wallet::COutput& a, const wallet::COutput& b) {
+                  return minimize_inputs ? a.txout.nValue > b.txout.nValue
+                                         : a.txout.nValue < b.txout.nValue;
               });
 
-    // Select UTXOs until fee covered, excluding any specified UTXOs
+    // Select UTXOs until the fee is covered in effective value, excluding any
+    // specified UTXOs
+    CAmount selected_effective = 0;
     for (const auto& coin : available_coins) {
-        if (selected_total >= fee_amount) break;
+        if (selected_effective >= fee_amount) break;
         if (require_confirmed_fee_inputs && coin.depth < 1) {
             LogPrint(BCLog::DIGIDOLLAR, "DigiDollar: SelectFeeCoins - skipping unconfirmed fee UTXO %s:%u while Dandelion is enabled\n",
                      coin.outpoint.hash.ToString(), coin.outpoint.n);
@@ -6254,28 +6320,112 @@ bool DigiDollarWallet::SelectFeeCoins(const CAmount& fee_amount, std::vector<COu
             if (should_exclude) continue;
         }
 
+        // A UTXO worth no more than it costs to spend can never help pay the
+        // fee: including it would lower the amount available to pay with.
+        if (amount <= input_spend_cost) {
+            LogPrint(BCLog::DIGIDOLLAR, "DigiDollar: SelectFeeCoins - skipping uneconomic fee UTXO %s:%u (%lld sats, costs %lld sats to spend)\n",
+                     outpoint.hash.ToString(), outpoint.n,
+                     static_cast<long long>(amount), static_cast<long long>(input_spend_cost));
+            continue;
+        }
+
         selected_utxos.push_back(outpoint);
         if (selected_amounts) selected_amounts->push_back(amount);
         selected_total += amount;
+        selected_effective += amount - input_spend_cost;
 
-        LogPrintf("DigiDollar: SelectFeeCoins - Selected UTXO %s:%u (%lld sats)\n",
-                  outpoint.hash.ToString(), outpoint.n, static_cast<long long>(amount));
+        LogPrintf("DigiDollar: SelectFeeCoins - Selected UTXO %s:%u (%lld sats, %lld sats effective)\n",
+                  outpoint.hash.ToString(), outpoint.n, static_cast<long long>(amount),
+                  static_cast<long long>(amount - input_spend_cost));
     }
 
-    bool success = (selected_total >= fee_amount);
+    bool success = (selected_effective >= fee_amount);
 
     if (!success) {
-        LogPrintf("DigiDollar: SelectFeeCoins - FAILED: need %lld sats, have %lld\n",
-                  static_cast<long long>(fee_amount), static_cast<long long>(selected_total));
+        LogPrintf("DigiDollar: SelectFeeCoins - FAILED: need %lld sats, have %lld sats effective (%lld sats raw from %zu UTXOs)\n",
+                  static_cast<long long>(fee_amount), static_cast<long long>(selected_effective),
+                  static_cast<long long>(selected_total), selected_utxos.size());
         selected_utxos.clear();
         if (selected_amounts) selected_amounts->clear();
         selected_total = 0;
     } else {
-        LogPrintf("DigiDollar: SelectFeeCoins - SUCCESS: selected %lld sats from %zu UTXOs\n",
-                  static_cast<long long>(selected_total), selected_utxos.size());
+        LogPrintf("DigiDollar: SelectFeeCoins - SUCCESS: selected %lld sats (%lld sats effective) from %zu UTXOs\n",
+                  static_cast<long long>(selected_total), static_cast<long long>(selected_effective),
+                  selected_utxos.size());
     }
 
     return success;
+}
+
+DDFeeSelectionResult DigiDollarWallet::SelectRedemptionFeeCoins(DigiDollar::TxBuilderRedeemParams& params,
+                                                                std::string& error,
+                                                                CAmount* projected_fee) const
+{
+    // Bound the select/re-project loop; each round can only raise the fee
+    // target, so a handful of rounds is plenty for any convergent wallet.
+    static constexpr int MAX_FEE_SELECTION_ATTEMPTS = 6;
+
+    error.clear();
+    params.feeUtxos.clear();
+    params.feeAmounts.clear();
+
+    // Never fund the fee from the collateral being released or from the DD
+    // tokens being burned.
+    std::vector<COutPoint> exclude_utxos;
+    exclude_utxos.reserve(1 + params.ddUtxos.size());
+    exclude_utxos.push_back(params.collateralOutpoint);
+    exclude_utxos.insert(exclude_utxos.end(), params.ddUtxos.begin(), params.ddUtxos.end());
+
+    // Seed the target with the fee of a redemption carrying no fee inputs; each
+    // round then re-projects the transaction and raises the target by whatever
+    // the inputs it picked added to the fee.
+    size_t projected_vsize = 0;
+    CAmount required_fee = 0;
+    if (!PreflightDDRedemptionCapacity(params, error, &projected_vsize, &required_fee)) {
+        return DDFeeSelectionResult::INVALID_TRANSACTION;
+    }
+
+    CAmount fee_target = required_fee;
+    CAmount selected_total = 0;
+    for (int attempt = 0; attempt < MAX_FEE_SELECTION_ATTEMPTS; ++attempt) {
+        params.feeUtxos.clear();
+        params.feeAmounts.clear();
+        selected_total = 0;
+        if (!SelectFeeCoins(fee_target, params.feeUtxos, selected_total, &params.feeAmounts,
+                            &exclude_utxos, /*minimize_inputs=*/true, /*fee_rate=*/params.feeRate)) {
+            error = strprintf("Insufficient spendable DGB for the redemption fee: need %lld sats net of the cost of spending the fee inputs (about %lld sats per input at %lld sat/kvB). Add DGB, or consolidate small DGB UTXOs into fewer, larger ones and retry.",
+                              static_cast<long long>(fee_target),
+                              static_cast<long long>(DigiDollar::EstimateInputSpendCost(params.feeRate)),
+                              static_cast<long long>(params.feeRate));
+            return DDFeeSelectionResult::INSUFFICIENT_FUNDS;
+        }
+
+        if (!PreflightDDRedemptionCapacity(params, error, &projected_vsize, &required_fee)) {
+            params.feeUtxos.clear();
+            params.feeAmounts.clear();
+            return DDFeeSelectionResult::INVALID_TRANSACTION;
+        }
+
+        if (selected_total >= required_fee) {
+            if (projected_fee) *projected_fee = required_fee;
+            // required_fee is an upper bound: the projection carries a worst-case
+            // output set, so the built transaction may owe slightly less.
+            LogPrintf("DigiDollar: Redemption fee inputs converged after %d round(s): %zu input(s) totalling %lld sats for a projected %u vB transaction owing at most %lld sats\n",
+                      attempt + 1, params.feeUtxos.size(), static_cast<long long>(selected_total),
+                      static_cast<unsigned>(projected_vsize), static_cast<long long>(required_fee));
+            return DDFeeSelectionResult::OK;
+        }
+
+        // Short by exactly this much once the selected inputs are paid for.
+        fee_target += required_fee - selected_total;
+    }
+
+    error = strprintf("Could not assemble DGB fee inputs for this redemption after %d attempts: last selection was %zu input(s) totalling %lld sats against a projected %lld sat fee. The wallet's DGB is too fragmented - consolidate small DGB UTXOs into fewer, larger ones and retry.",
+                      MAX_FEE_SELECTION_ATTEMPTS, params.feeUtxos.size(),
+                      static_cast<long long>(selected_total), static_cast<long long>(required_fee));
+    params.feeUtxos.clear();
+    params.feeAmounts.clear();
+    return DDFeeSelectionResult::INSUFFICIENT_FUNDS;
 }
 
 CAmount DigiDollarWallet::CalculateTransactionFee(const CMutableTransaction& tx) const {
@@ -6285,10 +6435,10 @@ CAmount DigiDollarWallet::CalculateTransactionFee(const CMutableTransaction& tx)
     static const CAmount MIN_RELAY_FEE_PER_KB = 100000;  // 0.001 DGB/kB (matches network min relay fee)
     // Bug #9 fix: Use the actual DD fee rate (35M sat/kB) instead of the generic 200K sat/kB.
     // DD transactions require higher fees to ensure relay at the DD minimum fee rate.
-    static const CAmount DEFAULT_FEE_RATE = 35000000;    // 0.35 DGB/kB (matches MIN_DD_FEE_RATE)
+    static const CAmount DEFAULT_FEE_RATE = DigiDollar::MIN_DD_FEE_RATE;
 
     // DigiDollar transactions MUST pay at least 0.1 DGB fee to miners
-    static const CAmount MIN_DD_TX_FEE = 10000000;       // 0.1 DGB minimum for DigiDollar transactions
+    static const CAmount MIN_DD_TX_FEE = DigiDollar::MIN_DD_TX_FEE;
 
     // Calculate transaction size
     // NOTE: This is an estimate. Actual size determined after signing

--- a/src/wallet/digidollarwallet.h
+++ b/src/wallet/digidollarwallet.h
@@ -138,6 +138,17 @@ struct DDTransferPlan {
     CAmount estimated_fee{0};
 };
 
+/** Outcome of DigiDollarWallet::SelectRedemptionFeeCoins(). */
+enum class DDFeeSelectionResult {
+    OK,
+    //! The wallet cannot fund the fee: not enough spendable DGB once the cost of
+    //! spending each fee input is accounted for, or the DGB is too fragmented.
+    INSUFFICIENT_FUNDS,
+    //! The redemption cannot be built as specified: invalid fee rate, or the
+    //! projected transaction exceeds MAX_STANDARD_TX_WEIGHT.
+    INVALID_TRANSACTION,
+};
+
 /**
  * DigiDollar wallet functionality
  * Provides high-level interface for DD operations
@@ -810,7 +821,56 @@ public:
     bool SelectDDCoins(const CAmount& target_amount, std::vector<COutPoint>& selected_utxos, CAmount& selected_total, std::vector<CAmount>* amounts = nullptr) const;
     bool SelectDDCoins(const CAmount& target_amount, const std::vector<COutPoint>& preset_inputs, std::vector<COutPoint>& selected_utxos, CAmount& selected_total, std::vector<CAmount>* amounts = nullptr, std::string* error = nullptr) const;
     bool PlanDigiDollarTransfer(const std::vector<std::pair<CDigiDollarAddress, CAmount>>& recipients, DDTransferPlan& plan, std::string& error, const std::vector<COutPoint>* preset_dd_inputs = nullptr) const;
-    bool SelectFeeCoins(const CAmount& fee_amount, std::vector<COutPoint>& selected_utxos, CAmount& selected_total, std::vector<CAmount>* selected_amounts = nullptr, const std::vector<COutPoint>* exclude_utxos = nullptr) const;
+    /**
+     * Select spendable DGB UTXOs to fund a DigiDollar transaction fee.
+     *
+     * Spending an input is not free: each extra fee input costs
+     * DigiDollar::EstimateInputSpendCost(fee_rate) to spend. UTXOs are therefore
+     * priced by effective value (value minus that cost); UTXOs with a
+     * non-positive effective value are skipped, and `fee_amount` must be covered
+     * by the sum of the effective values, not by the raw sum.
+     *
+     * @param[in]  fee_amount       Fee, in satoshis, the selection must still
+     *                              cover after paying for its own inputs.
+     * @param[out] selected_utxos   Chosen outpoints.
+     * @param[out] selected_total   RAW total value of the chosen outpoints.
+     * @param[out] selected_amounts Per-outpoint values, parallel to selected_utxos.
+     * @param[in]  exclude_utxos    Outpoints that must not be selected.
+     * @param[in]  minimize_inputs  Prefer high-value UTXOs so the selection uses
+     *                              as few inputs as possible. Off by default,
+     *                              which keeps the smallest-first order DD
+     *                              transfers have always used: it spends down
+     *                              small UTXOs at the cost of a larger fee.
+     *                              Redemption opts in because it must converge
+     *                              on an exact fee.
+     * @param[in]  fee_rate         Fee rate, in satoshis per kvB, the transaction
+     *                              will pay. Must be positive; it is what makes
+     *                              the per-input cost meaningful, so a caller
+     *                              spending at a rate other than the DigiDollar
+     *                              minimum has to pass its own.
+     */
+    bool SelectFeeCoins(const CAmount& fee_amount, std::vector<COutPoint>& selected_utxos, CAmount& selected_total, std::vector<CAmount>* selected_amounts = nullptr, const std::vector<COutPoint>* exclude_utxos = nullptr, bool minimize_inputs = false, CAmount fee_rate = DigiDollar::MIN_DD_FEE_RATE) const;
+
+    /**
+     * Select the DGB fee inputs for a DigiDollar redemption, converging on the
+     * fee the built transaction will actually owe.
+     *
+     * The fee of a DigiDollar transaction depends on how many inputs it ends up
+     * with, so it cannot be known from a fixed size guess: each selection round
+     * re-projects the redemption transaction and re-selects against the updated
+     * fee. Fills params.feeUtxos / params.feeAmounts on success and excludes the
+     * collateral outpoint and the DD UTXOs being burned from the selection, so
+     * that a redemption can never pay its fee out of the collateral it releases
+     * or the DD it burns.
+     *
+     * @param[in,out] params        Redemption parameters; fee inputs are filled in.
+     * @param[out]    error         Actionable message when the result is not OK.
+     * @param[out]    projected_fee Upper bound on the fee the built redemption
+     *                              will owe (the projection carries a worst-case
+     *                              output set, so the final fee can be lower).
+     */
+    DDFeeSelectionResult SelectRedemptionFeeCoins(DigiDollar::TxBuilderRedeemParams& params, std::string& error, CAmount* projected_fee = nullptr) const;
+
     CAmount CalculateTransactionFee(const CMutableTransaction& tx) const;
 
     // Phase 3.1: P2TR signing for DD inputs (Schnorr signatures)

--- a/test/functional/digidollar_redeem_fragmented_fees.py
+++ b/test/functional/digidollar_redeem_fragmented_fees.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Test DigiDollar redemption on a wallet with fragmented DGB.
+
+Regression test for redeemdigidollar failing with
+"Insufficient fee inputs for DD redemption fee" on a wallet whose spendable DGB
+is fragmented into small UTXOs, even when the wallet holds plenty of DGB.
+
+Spending a fee input is not free: it enlarges the transaction the DigiDollar fee
+is computed from, so at the DigiDollar fee rate (35,000,000 sat/kvB) each extra
+fee input costs ~3,220,000 sat (~0.0322 DGB) to spend. Fee coin selection used to
+sort smallest-first and stop once the RAW sum of the picked UTXOs reached the
+target, so on a fragmented wallet it handed back a pile of small UTXOs whose net
+contribution was far below the fee, and the redemption builder - which recomputes
+the fee from the transaction it actually built - rejected it outright. There was
+no re-selection.
+
+Here the wallet is deliberately stocked with 0.0525 DGB UTXOs, just above that
+per-input cost: four of them raise exactly the 21,000,000 sat the old fixed fee
+estimate asked for, while contributing only 8,120,000 sat once the cost of
+spending them is paid. The redemption must still succeed, and must not drag the
+fragmented UTXOs in.
+"""
+
+from decimal import Decimal
+
+from test_framework.test_framework import DigiByteTestFramework
+from test_framework.util import (
+    assert_equal,
+    assert_greater_than,
+)
+
+# Just above the ~0.0322 DGB it costs to spend one fee input at the DigiDollar
+# fee rate: individually economic, collectively unable to pay the fee.
+FRAGMENT_AMOUNT = Decimal("0.0525")
+NUM_FRAGMENTS = 12
+DD_MINT_CENTS = 100000  # $1000.00
+LOCK_TIER = 0           # 1 hour = 240 blocks
+
+
+class DigiDollarRedeemFragmentedFeesTest(DigiByteTestFramework):
+    def set_test_params(self):
+        self.num_nodes = 1
+        self.setup_clean_chain = True
+        self.extra_args = [
+            ["-digidollar=1", "-mocktime=0", "-dandelion=0", "-txindex=1"],
+        ]
+
+    def add_options(self, parser):
+        self.add_wallet_options(parser)
+
+    def skip_test_if_missing_module(self):
+        self.skip_if_no_wallet()
+
+    def run_test(self):
+        node = self.nodes[0]
+
+        self.log.info("Generating blocks past the DigiDollar activation height")
+        self.generate(node, 655)
+        node.setmockoracleprice(10000)  # $0.01/DGB in micro-USD
+
+        self.log.info("Minting $1000 DD with a 1-hour timelock")
+        mint_result = node.mintdigidollar(DD_MINT_CENTS, LOCK_TIER)
+        position_id = mint_result['position_id']
+        unlock_height = mint_result['unlock_height']
+        assert_equal(mint_result['dd_minted'], DD_MINT_CENTS)
+        self.generate(node, 10)
+        assert_equal(node.getdigidollarbalance()['total'], DD_MINT_CENTS)
+
+        self.log.info(f"Fragmenting the wallet into {NUM_FRAGMENTS} x {FRAGMENT_AMOUNT} DGB UTXOs")
+        for _ in range(NUM_FRAGMENTS):
+            node.sendtoaddress(node.getnewaddress(), FRAGMENT_AMOUNT)
+        self.generate(node, 2)
+
+        fragments = [
+            (utxo['txid'], utxo['vout'])
+            for utxo in node.listunspent()
+            if utxo['amount'] == FRAGMENT_AMOUNT
+        ]
+        self.log.info(f"Wallet now holds {len(fragments)} fragmented fee-sized UTXOs")
+        assert_greater_than(len(fragments), 4)  # enough to reproduce the old selection
+
+        self.log.info("Advancing past the unlock height")
+        self.generate(node, unlock_height - node.getblockcount() + 10)
+        assert_greater_than(node.getblockcount(), unlock_height)
+
+        # Before the effective-value fix this call raised
+        # "Insufficient fee inputs for DD redemption fee": fee selection returned
+        # four fragmented UTXOs totalling exactly the estimated fee, which could
+        # not cover the fee of the transaction they were part of.
+        self.log.info("Redeeming the position from the fragmented wallet")
+        redeem_result = node.redeemdigidollar(position_id, DD_MINT_CENTS)
+        redeem_txid = redeem_result['txid']
+        assert_equal(redeem_result['dd_redeemed'], DD_MINT_CENTS)
+        assert_equal(redeem_result['position_closed'], True)
+
+        self.log.info("Checking the redemption did not spend the uneconomic UTXOs")
+        redeem_tx = node.getrawtransaction(redeem_txid, True)
+        spent = {(vin['txid'], vin['vout']) for vin in redeem_tx['vin'] if 'txid' in vin}
+        used_fragments = spent.intersection(fragments)
+        assert_equal(used_fragments, set())
+
+        self.log.info("Confirming the redemption")
+        self.generate(node, 5)
+        assert_equal(node.getrawtransaction(redeem_txid, True).get('confirmations', 0) > 0, True)
+        assert_equal(node.getdigidollarbalance()['total'], 0)
+
+        active = [p for p in node.listdigidollarpositions() if p.get('is_active', False)]
+        for position in active:
+            assert position['position_id'] != position_id, "Redeemed position should be inactive"
+
+        self.log.info("Redemption from a fragmented wallet succeeded")
+
+
+if __name__ == '__main__':
+    DigiDollarRedeemFragmentedFeesTest().main()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -263,6 +263,7 @@ BASE_SCRIPTS = [
     'digidollar_persistence.py',
     'digidollar_network_tracking.py',
     'digidollar_redeem.py',
+    'digidollar_redeem_fragmented_fees.py',
     'digidollar_redemption_e2e.py',
     'digidollar_transactions.py',
     'digidollar_wallet.py',


### PR DESCRIPTION
## Problem

`redeemdigidollar` fails on wallets whose DGB is fragmented into small UTXOs, even when the wallet holds ample spendable DGB:

```
Failed to build redemption transaction: Insufficient fee inputs for DD redemption fee (-4)
```

This is reachable in ordinary use — any wallet that has accumulated small payments (mining payouts, tips, faucet drips) can hit it, and the practical workaround has been to consolidate UTXOs by hand first. It is the redemption analogue of the fragmented-UTXO mint bug fixed in #396.

## Root cause

A fee UTXO's *raw* value is not its contribution to the fee, because every input added to a DigiDollar transaction enlarges the transaction the fee is computed from.

At the DD fee rate (35,000,000 sat/kvB) and with the per-input accounting in `DigiDollar::EstimateTransactionVSize()` (41 base bytes + a flat 110 witness bytes, +35% margin ≈ 92 vB), **one extra input costs about 3,220,000 sat (~0.0322 DGB) to spend**. Any fee UTXO below that threshold has *negative effective value* — adding it reduces the amount available to pay the fee.

Three things then interact:

1. `DigiDollarWallet::SelectFeeCoins()` sorted **smallest-first** and stopped as soon as the raw sum reached the target — so it selected precisely the UTXOs that cannot pay for their own spending.
2. `redeemdigidollar` asked for a fixed `(400 vB × feeRate) + 50%` estimate that was never revisited — a hard budget of ~600 vB, exhausted after roughly 3–4 fee inputs.
3. `BuildRedemptionTransaction()` recomputed the true fee from the transaction it had actually built and failed when the selection came up short, with no re-selection.

Worked example from the regression test: four 0.0525 DGB UTXOs total 21,000,000 sat against a 21,000,000 sat target, but spending them costs 12,880,000 sat, leaving 8,120,000 sat effective — while an untouched 5 DGB UTXO sat in the same wallet.

Note that simply enlarging the fixed estimate does **not** fix this: a bigger target just pulls in more uneconomic inputs, and the spend cost scales with it.

## Fix

`SelectFeeCoins()` now prices every candidate by **effective value** (`value - EstimateInputSpendCost(fee_rate)`), skips UTXOs that cannot pay for their own spending, and requires the target to be met in effective rather than raw value. `selected_total` keeps its raw meaning. This applies to all callers, because a selection whose raw sum meets the target but whose effective sum does not is arithmetically wrong on every path. The fee rate is now a parameter so the cost tracks what the transaction will actually pay.

Input **ordering** stays opt-in: a new `minimize_inputs` flag, off by default, preserves the smallest-first order DD transfers have always used. Only the redemption path sets it.

`DigiDollarWallet::SelectRedemptionFeeCoins()` applies the pattern **this codebase already uses for DD transfers** in `PreflightDDTransferCapacity()`: build a projected transaction from the actually-selected inputs, derive the fee from `EstimateTransactionVSize()`, and re-select against the updated fee, bounded to six rounds. It preserves the `MIN_DD_TX_FEE` floor and the `MAX_STANDARD_TX_WEIGHT` guard, excludes the collateral outpoint and the DD UTXOs being burned, and reports its outcome as a category so the RPC can distinguish a funding shortfall from a transaction that cannot be built.

Failures now name the numbers and tell the user to consolidate, instead of a bare `"Insufficient fee inputs"`.

`MIN_DD_FEE_RATE` and `MIN_DD_TX_FEE` move to `txbuilder.h`, replacing copies scattered across the wallet and RPC.

**No consensus code is touched.** Mint is unaffected — it funds itself through `TxBuilder::SelectCoins` (which, incidentally, already sorts largest-first with the comment *"This minimizes the number of inputs needed"*).

## Behaviour change worth calling out

`senddigidollar` on a fragmented wallet changes: selection that previously came up short now succeeds, using several small inputs and paying a correspondingly larger fee. On the wallet in the regression test that is ~0.249 DGB across five small inputs, where a single large input would have cost ~0.12 DGB.

This is a fail → succeed change, so it is an improvement, but it is a real change and reviewers should see it stated rather than discover it. Flipping the transfer default to `minimize_inputs` would reduce that fee; it is deliberately left out of this PR to keep the blast radius contained, and can follow separately if maintainers prefer.

## Testing

**Unit** (`src/test/digidollar_wallet_tests.cpp`, all additions — no existing assertion was modified or removed):
- fragmented uneconomic UTXO selection (the original repro)
- redemption fee convergence on a fragmented wallet
- fee-rate independence at 100,000 sat/kvB
- the collateral/DD exclusion guard
- dust-only and empty wallets fail with actionable messages

The exclusion-guard test is mutation-checked: injecting `exclude_utxos.clear()` fails it 5/5.

**Functional:** new `test/functional/digidollar_redeem_fragmented_fees.py` — mints $1000 DD, fragments the wallet into 12 × 0.0525 DGB, matures, and redeems. Reverting the source changes reproduces the original `Insufficient fee inputs for DD redemption fee (-4)` failure; with the fix it passes.

Full unit suite: **3414/3414 passing**. `digidollar_redemption_e2e.py` also still passes, confirming the ordinary redemption path is unaffected.

---

*Prepared with AI assistance; all changes were human-reviewed, and every test result above was independently reproduced before submission.*
